### PR TITLE
CSS Animations fix, Image masking fix

### DIFF
--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlasinc/rrweb-snapshot",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -67,7 +67,11 @@ function getAllBrokenAnimationProperties(cssString: string): string[] {
 function getCssRulesString(doc: Document, s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules;
-    return rules ? Array.from(rules).map(rule => getCssRuleString(doc, rule)).join('') : null;
+    return rules
+      ? Array.from(rules)
+          .map((rule) => getCssRuleString(doc, rule))
+          .join('')
+      : null;
   } catch (error) {
     return null;
   }
@@ -77,7 +81,8 @@ function getCssRuleString(doc: Document, rule: CSSRule | CSSStyleRule): string {
   let cssStringified = rule.cssText;
   if (isCSSImportRule(rule)) {
     try {
-      cssStringified = getCssRulesString(doc, rule.styleSheet) || cssStringified;
+      cssStringified =
+        getCssRulesString(doc, rule.styleSheet) || cssStringified;
     } catch {
       // ignore
     }
@@ -87,7 +92,8 @@ function getCssRuleString(doc: Document, rule: CSSRule | CSSStyleRule): string {
     cssStringified,
   );
   if (animationPropsWithEmptyValues.length > 0) {
-    const actualElement = 'selectorText' in rule && doc.querySelector(rule.selectorText);
+    const actualElement =
+      'selectorText' in rule && doc.querySelector(rule.selectorText);
 
     if (actualElement && window) {
       const computedStyle = window.getComputedStyle(actualElement);
@@ -362,10 +368,10 @@ function onceIframeLoaded(
   iframeEl.addEventListener('load', listener);
 }
 
-function stringifyStyleSheet(sheet: CSSStyleSheet): string {
+function stringifyStyleSheet(doc: Document, sheet: CSSStyleSheet): string {
   return sheet.cssRules
     ? Array.from(sheet.cssRules)
-        .map((rule) => rule.cssText || '')
+        .map((rule) => getCssRuleString(doc, rule))
         .join('')
     : '';
 }
@@ -648,6 +654,7 @@ function serializeNode(
           // try to read style sheet
           if ((n.parentNode as HTMLStyleElement).sheet?.cssRules) {
             textContent = stringifyStyleSheet(
+              doc,
               (n.parentNode as HTMLStyleElement).sheet!,
             );
           }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -46,24 +46,61 @@ function getValidTagName(element: HTMLElement): string {
   return processedTagName;
 }
 
-function getCssRulesString(s: CSSStyleSheet): string | null {
+function getAllBrokenAnimationProperties(cssString: string): string[] {
+  // Match all instances of CSS properties starting with "animation" or exactly "animation" with missing values
+  const propertiesWithMissingValues: string[] = [];
+  const regex = /\b(animation[\w-]*):\s*(var\([^)]*\))?;\s*/g;
+
+  let match = regex.exec(cssString);
+  while (match !== null) {
+    const [, property, variable] = match;
+    if (!variable) {
+      propertiesWithMissingValues.push(property);
+    }
+
+    match = regex.exec(cssString);
+  }
+
+  return propertiesWithMissingValues;
+}
+
+function getCssRulesString(doc: Document, s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules;
-    return rules ? Array.from(rules).map(getCssRuleString).join('') : null;
+    return rules ? Array.from(rules).map(rule => getCssRuleString(doc, rule)).join('') : null;
   } catch (error) {
     return null;
   }
 }
 
-function getCssRuleString(rule: CSSRule): string {
+function getCssRuleString(doc: Document, rule: CSSRule | CSSStyleRule): string {
   let cssStringified = rule.cssText;
   if (isCSSImportRule(rule)) {
     try {
-      cssStringified = getCssRulesString(rule.styleSheet) || cssStringified;
+      cssStringified = getCssRulesString(doc, rule.styleSheet) || cssStringified;
     } catch {
       // ignore
     }
   }
+
+  const animationPropsWithEmptyValues = getAllBrokenAnimationProperties(
+    cssStringified,
+  );
+  if (animationPropsWithEmptyValues.length > 0) {
+    const actualElement = 'selectorText' in rule && doc.querySelector(rule.selectorText);
+
+    if (actualElement && window) {
+      const computedStyle = window.getComputedStyle(actualElement);
+      for (const prop of animationPropsWithEmptyValues) {
+        const computedValue = computedStyle[prop as keyof CSSStyleDeclaration];
+        cssStringified = cssStringified.replace(
+          `${prop}: ;`,
+          `${prop}: ${computedValue};`,
+        );
+      }
+    }
+  }
+
   return cssStringified;
 }
 
@@ -414,7 +451,7 @@ function serializeNode(
         const stylesheet = Array.from(doc.styleSheets).find((s) => {
           return s.href === (n as HTMLLinkElement).href;
         });
-        const cssText = getCssRulesString(stylesheet as CSSStyleSheet);
+        const cssText = getCssRulesString(doc, stylesheet as CSSStyleSheet);
         if (cssText) {
           delete attributes.rel;
           delete attributes.href;
@@ -436,6 +473,7 @@ function serializeNode(
         ).trim().length
       ) {
         const cssText = getCssRulesString(
+          doc,
           (n as HTMLStyleElement).sheet as CSSStyleSheet,
         );
         if (cssText) {
@@ -450,7 +488,10 @@ function serializeNode(
       ) {
         const value = (n as HTMLInputElement | HTMLTextAreaElement).value;
 
-        if (typeof attributes.placeholder === 'string' && attributes.placeholder.length > 0) {
+        if (
+          typeof attributes.placeholder === 'string' &&
+          attributes.placeholder.length > 0
+        ) {
           attributes.placeholder = maskInputValue({
             type: attributes.type,
             tagName,

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -541,14 +541,40 @@ export default class MutationBuffer {
         }
 
         if (tagName === 'img') {
-          const attrs = maskImage({
-            n: target as HTMLImageElement,
-            attributes: item.attributes as { [p: string]: string },
-            maskImageFn: this.maskImageFn,
-          });
+          const needsMasking = needMaskingText(
+            m.target,
+            this.maskTextClass,
+            this.maskTextSelector,
+            this.maskAll,
+          );
 
-          for (const [attr, val] of Object.entries(attrs)) {
-            item.attributes[attr] = val as string;
+          if (needsMasking) {
+            const attrs = maskImage({
+              n: target as HTMLImageElement,
+              attributes: item.attributes as { [p: string]: string },
+              maskImageFn: this.maskImageFn,
+            });
+
+            for (const [attr, val] of Object.entries(attrs)) {
+              item.attributes[attr] = val as string;
+            }
+          } else {
+            // reset attributes if needed
+            const attributesToReset = ['src', 'srcset', 'alt'].filter(a => a !== m.attributeName);
+
+            for (const attr of attributesToReset) {
+              const targetValue = target.getAttribute(attr) || '';
+              const attributeNewValue = transformAttribute(
+                this.doc,
+                target.tagName,
+                attr,
+                targetValue,
+              );
+
+              if (item.attributes[attr] !== attributeNewValue) {
+                item.attributes[attr] = attributeNewValue;
+              }
+            }
           }
         }
         break;


### PR DESCRIPTION
- Use computed styles for `animation` in cases when css variables are not resolved
- Fix image masking issue, it was being masked on every mutation (attribute change) even when selector was not matching