### PR TITLE
[ENG-5023] Fix inactivity for consecutive interaction events

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -522,7 +522,7 @@ export class Replayer {
       this.nextUserInteractionEvent = null;
       this.backToNormal();
     }
-    if (this.config.skipInactive && !isUserInteraction(event)) {
+    if (this.config.skipInactive) {
       if (!this.nextUserInteractionEvent) {
         let hasFollowingInteraction = false;
         for (const _event of this.service.state.context.events) {

--- a/packages/rrweb/src/replay/utils.ts
+++ b/packages/rrweb/src/replay/utils.ts
@@ -31,7 +31,6 @@ export function getInactivityRanges(
   events.forEach((event, idx) => {
     if (isUserInteraction(event)) {
       lastInteraction = event;
-      return;
     }
 
     const nextUserInteractionEvent = events.slice(idx + 1).find(isUserInteraction);

--- a/packages/rrweb/test/replay/utils.test.ts
+++ b/packages/rrweb/test/replay/utils.test.ts
@@ -1,0 +1,217 @@
+import { EventType, IncrementalSource } from 'rrweb';
+import {
+  getInactivityRanges,
+  SKIP_TIME_THRESHOLD,
+} from '../../src/replay/utils';
+import { eventWithTime } from '../../src/types';
+
+const createEvent = (
+  timestamp: number,
+  type: number,
+  source?: IncrementalSource,
+): eventWithTime => ({
+  timestamp,
+  type,
+  data: {
+    source,
+  },
+});
+
+describe('getInactivityRanges', () => {
+  const durationInSeconds = 20;
+  const START_TIME = 1;
+  const END_TIME = durationInSeconds * 1000;
+
+  test('returns an empty array when there are no events', () => {
+    const events: eventWithTime[] = [];
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+    expect(result).toEqual([]);
+  });
+
+  test('returns no inactivity ranges when interactions are frequent', () => {
+    let events: eventWithTime[] = [];
+    for (let i = 0; i < durationInSeconds; i++) {
+      events.push(
+        createEvent(
+          START_TIME + i * 1000,
+          EventType.IncrementalSnapshot,
+          IncrementalSource.MouseMove,
+        ),
+      );
+    }
+
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+    expect(result).toEqual([]);
+  });
+
+  test('returns correct inactivity ranges when there is inactivity', () => {
+    const events = [
+      createEvent(
+        START_TIME,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.MouseMove,
+      ),
+      createEvent(
+        START_TIME + 1000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Input,
+      ),
+      // Inactivity period > SKIP_TIME_THRESHOLD (10 seconds)
+      createEvent(
+        START_TIME + SKIP_TIME_THRESHOLD + 5000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Input,
+      ),
+    ];
+
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+
+    expect(result).toEqual([
+      {
+        startMs: 1000,
+        endMs: SKIP_TIME_THRESHOLD + 5000,
+        startTime: '00:01',
+        endTime: '00:15',
+      },
+    ]);
+  });
+
+  test('handles inactivity range at the end of the event list', () => {
+    let events: eventWithTime[] = [];
+    const skipTimeSecs = SKIP_TIME_THRESHOLD / 1000;
+    for (let i = 0; i < durationInSeconds - skipTimeSecs; i++) {
+      events.push(
+        createEvent(
+          START_TIME + i * 1000,
+          EventType.IncrementalSnapshot,
+          IncrementalSource.MouseMove,
+        ),
+      );
+    }
+
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+
+    // Inactivity from the last interaction to the end time
+    expect(result).toEqual([
+      {
+        startMs: (durationInSeconds - skipTimeSecs - 1) * 1000,
+        endMs: END_TIME - START_TIME,
+        startTime: '00:09',
+        endTime: '00:19',
+      },
+    ]);
+  });
+
+  test('does not add duplicate inactivity ranges', () => {
+    const events = [
+      createEvent(
+        START_TIME,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.MouseMove,
+      ),
+      createEvent(
+        START_TIME + 1000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Input,
+      ),
+      createEvent(
+        START_TIME + SKIP_TIME_THRESHOLD + 5000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Input,
+      ),
+      createEvent(
+        START_TIME + SKIP_TIME_THRESHOLD + 6000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Input,
+      ),
+    ];
+
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+
+    // Should only add one inactivity range despite multiple close events
+    expect(result).toEqual([
+      {
+        startMs: 1000,
+        endMs: SKIP_TIME_THRESHOLD + 5000,
+        startTime: '00:01',
+        endTime: '00:15',
+      },
+    ]);
+  });
+
+  test('handles no user interactions after initial events', () => {
+    const events = [
+      createEvent(START_TIME, EventType.FullSnapshot),
+      createEvent(
+        START_TIME + 1000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.MouseMove,
+      ),
+      createEvent(
+        START_TIME + 2000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Mutation,
+      ), // Non-interaction event
+      createEvent(
+        START_TIME + 5000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Mutation,
+      ), // Non-interaction event
+    ];
+
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+
+    // Entire remaining period is inactivity
+    expect(result).toEqual([
+      {
+        startMs: 1000,
+        endMs: END_TIME - START_TIME,
+        startTime: '00:01',
+        endTime: '00:19',
+      },
+    ]);
+  });
+
+  test('handles inactivity range between two interactions', () => {
+    const events = [
+      createEvent(START_TIME, EventType.FullSnapshot),
+      createEvent(
+        START_TIME + 1000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.MouseMove,
+      ),
+      createEvent(
+        START_TIME + 3000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Mutation,
+      ), // Non-interaction event
+      createEvent(
+        START_TIME + 5000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.ViewportResize,
+      ),
+      createEvent(
+        START_TIME + 9000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.Mutation,
+      ), // Non-interaction event
+      createEvent(
+        START_TIME + 17000,
+        EventType.IncrementalSnapshot,
+        IncrementalSource.ViewportResize,
+      ),
+    ];
+
+    const result = getInactivityRanges(events, START_TIME, END_TIME);
+
+    // Inactivity between 2 ViewPortResize events
+    expect(result).toEqual([
+      {
+        startMs: 5000,
+        endMs: 17000,
+        startTime: '00:05',
+        endTime: '00:17',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes an issue with detecting inactivity ranges when there are two user interactions that are far apart in time:

Event => 1724703014580, 2024-08-26T20:10:14.580Z, Meta 
Event => 1724703014608, 2024-08-26T20:10:14.608Z, FullSnapshot 
Event => 1724703016897, 2024-08-26T20:10:16.897Z, IncrementalSnapshot, ViewportResize
Event => 1724703016898, 2024-08-26T20:10:16.898Z, IncrementalSnapshot, Mutation
Event => 1724703016997, 2024-08-26T20:10:16.997Z, IncrementalSnapshot, Mutation
**Event => 1724703017098, 2024-08-26T20:10:17.098Z, IncrementalSnapshot, ViewportResize
Event => 1724703110374, 2024-08-26T20:11:50.374Z, IncrementalSnapshot, ViewportResize**
Event => 1724703110378, 2024-08-26T20:11:50.378Z, IncrementalSnapshot, Mutation
Event => 1724703110499, 2024-08-26T20:11:50.499Z, IncrementalSnapshot, Mutation
Event => 1724703110574, 2024-08-26T20:11:50.574Z, IncrementalSnapshot, ViewportResize