### PR TITLE
Add css property shorthand to replay

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlasinc/rrweb",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -64,6 +64,11 @@ import {
 } from './virtual-styles';
 import { isUserInteraction, SKIP_TIME_INTERVAL, SKIP_TIME_THRESHOLD } from './utils';
 
+// Fix for Shopify's shorthand CSS properties (animation)
+// This is a PostHog way to fix it: https://github.com/PostHog/posthog/pull/22942
+const shopifyShorthandCSSFix =
+  '@media (prefers-reduced-motion: no-preference) { .scroll-trigger:not(.scroll-trigger--offscreen).animate--slide-in { animation: var(--animation-slide-in) } }'
+
 // https://github.com/rollup/rollup/issues/1267#issuecomment-296395734
 // tslint:disable-next-line
 const mitt = (mittProxy as any).default || mittProxy;
@@ -146,7 +151,7 @@ export class Replayer {
       showDebug: false,
       blockClass: 'rr-block',
       liveMode: false,
-      insertStyleRules: [],
+      insertStyleRules: [shopifyShorthandCSSFix],
       triggerFocus: true,
       UNSAFE_replayCanvas: false,
       pauseAnimation: true,


### PR DESCRIPTION
This is a fix from PostHog, they are basically inserting animation style rule during replay.
It means that old sessions content will also become visible for kidsy's broken recordings.

Confirmed it by downloading my broken session and replaying it using this fix:

![CleanShot 2024-09-17 at 11 08 26](https://github.com/user-attachments/assets/a780978f-461e-4a81-bae9-f3f5f3cd6e3e)
