### PR TITLE
Record and replay canvas v2

### DIFF
--- a/docs/recipes/canvas.md
+++ b/docs/recipes/canvas.md
@@ -1,23 +1,36 @@
 # Canvas
-
-Canvas is a special HTML element, which will not be recorded by rrweb by default. There are some options for recording and replaying Canvas.
-
+Canvas is a special HTML element, and will not be recorded by rrweb by default.
+There are some options for recording and replaying Canvas.
 Enable recording Canvas：
-
 ```js
 rrweb.record({
   emit(event) {},
   recordCanvas: true,
 });
 ```
+Alternatively enable image snapshot recording of Canvas at a maximum of 15 frames per second：
+```js
+rrweb.record({
+  emit(event) {},
+  recordCanvas: true,
+  sampling: {
+    canvas: 15,
+  },
+  // optional image format settings
+  dataURLOptions: {
+    type: 'image/webp',
+    quality: 0.6,
+  },
+});
+```
 
 Enable replaying Canvas：
-
 ```js
 const replayer = new rrweb.Replayer(events, {
   UNSAFE_replayCanvas: true,
 });
 replayer.play();
 ```
-
 **Enable replaying Canvas will remove the sandbox, which may cause a potential security issue.**
+Alternatively you can stream canvas elements via webrtc with the canvas-webrtc plugin.
+For more information see [canvas-webrtc documentation](../../packages/rrweb/src/plugins/canvas-webrtc/Readme.md)

--- a/guide.md
+++ b/guide.md
@@ -135,30 +135,31 @@ setInterval(save, 10 * 1000);
 
 The parameter of `rrweb.record` accepts the following options.
 
-| key                  | default            | description                                                  |
-| -------------------- | ------------------ | ------------------------------------------------------------ |
-| emit                 | required           | the callback function to get emitted events                  |
-| checkoutEveryNth     | -                  | take a full snapshot after every N events<br />refer to the [checkout](#checkout) chapter |
-| checkoutEveryNms     | -                  | take a full snapshot after every N ms<br />refer to the [checkout](#checkout) chapter |
-| blockClass           | 'rr-block'         | Use a string or RegExp to configure which elements should be blocked, refer to the [privacy](#privacy) chapter |
-| blockSelector        | null               | Use a string to configure which selector should be blocked, refer to the [privacy](#privacy) chapter |
-| ignoreClass          | 'rr-ignore'        | Use a string or RegExp to configure which elements should be ignored, refer to the [privacy](#privacy) chapter |
-| maskTextClass        | 'rr-mask'          | Use a string or RegExp to configure which elements should be masked, refer to the [privacy](#privacy) chapter |
-| maskTextSelector     | null               | Use a string to configure which selector should be masked, refer to the [privacy](#privacy) chapter |
-| maskAllInputs        | false              | mask all input content as \*                                 |
-| maskInputOptions     | { password: true } | mask some kinds of input \*<br />refer to the [list](https://github.com/rrweb-io/rrweb/blob/588164aa12f1d94576f89ae0210b98f6e971c895/packages/rrweb-snapshot/src/types.ts#L77-L95) |
-| maskInputFn          | -                  | customize mask input content recording logic                 |
-| maskTextFn           | -                  | customize mask text content recording logic                  |
-| slimDOMOptions       | {}                 | remove unnecessary parts of the DOM <br />refer to the [list](https://github.com/rrweb-io/rrweb/blob/588164aa12f1d94576f89ae0210b98f6e971c895/packages/rrweb-snapshot/src/types.ts#L97-L108) |
-| inlineStylesheet     | true               | whether to inline the stylesheet in the events               |
-| hooks                | {}                 | hooks for events<br />refer to the [list](https://github.com/rrweb-io/rrweb/blob/9488deb6d54a5f04350c063d942da5e96ab74075/src/types.ts#L207) |
-| packFn               | -                  | refer to the [storage optimization recipe](./docs/recipes/optimize-storage.md) |
-| sampling             | -                  | refer to the [storage optimization recipe](./docs/recipes/optimize-storage.md) |
-| recordCanvas         | false              | whether to record the canvas element                         |
-| inlineImages         | false              | whether to record the image content                          |
-| collectFonts         | false              | whether to collect fonts in the website                      |
+| key                  | default            | description                                                                                                                                                                                   |
+|----------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| emit                 | required           | the callback function to get emitted events                                                                                                                                                   |
+| checkoutEveryNth     | -                  | take a full snapshot after every N events<br />refer to the [checkout](#checkout) chapter                                                                                                     |
+| checkoutEveryNms     | -                  | take a full snapshot after every N ms<br />refer to the [checkout](#checkout) chapter                                                                                                         |
+| blockClass           | 'rr-block'         | Use a string or RegExp to configure which elements should be blocked, refer to the [privacy](#privacy) chapter                                                                                |
+| blockSelector        | null               | Use a string to configure which selector should be blocked, refer to the [privacy](#privacy) chapter                                                                                          |
+| ignoreClass          | 'rr-ignore'        | Use a string or RegExp to configure which elements should be ignored, refer to the [privacy](#privacy) chapter                                                                                |
+| maskTextClass        | 'rr-mask'          | Use a string or RegExp to configure which elements should be masked, refer to the [privacy](#privacy) chapter                                                                                 |
+| maskTextSelector     | null               | Use a string to configure which selector should be masked, refer to the [privacy](#privacy) chapter                                                                                           |
+| maskAllInputs        | false              | mask all input content as \*                                                                                                                                                                  |
+| maskInputOptions     | { password: true } | mask some kinds of input \*<br />refer to the [list](https://github.com/rrweb-io/rrweb/blob/588164aa12f1d94576f89ae0210b98f6e971c895/packages/rrweb-snapshot/src/types.ts#L77-L95)            |
+| maskInputFn          | -                  | customize mask input content recording logic                                                                                                                                                  |
+| maskTextFn           | -                  | customize mask text content recording logic                                                                                                                                                   |
+| slimDOMOptions       | {}                 | remove unnecessary parts of the DOM <br />refer to the [list](https://github.com/rrweb-io/rrweb/blob/588164aa12f1d94576f89ae0210b98f6e971c895/packages/rrweb-snapshot/src/types.ts#L97-L108)  |
+| dataURLOptions       | {}                 | Canvas image format and quality ,This parameter will be passed to the OffscreenCanvas.convertToBlob(),Using this parameter effectively reduces the size of the recorded data                  |
+| inlineStylesheet     | true               | whether to inline the stylesheet in the events                                                                                                                                                |
+| hooks                | {}                 | hooks for events<br />refer to the [list](https://github.com/rrweb-io/rrweb/blob/9488deb6d54a5f04350c063d942da5e96ab74075/src/types.ts#L207)                                                  |
+| packFn               | -                  | refer to the [storage optimization recipe](./docs/recipes/optimize-storage.md)                                                                                                                |
+| sampling             | -                  | refer to the [storage optimization recipe](./docs/recipes/optimize-storage.md)                                                                                                                |
+| recordCanvas         | false              | whether to record the canvas element                                                                                                                                                          |
+| inlineImages         | false              | whether to record the image content                                                                                                                                                           |
+| collectFonts         | false              | whether to collect fonts in the website                                                                                                                                                       |
 | userTriggeredOnInput | false              | whether to add `userTriggered` on input events that indicates if this event was triggered directly by the user or not. [What is `userTriggered`?](https://github.com/rrweb-io/rrweb/pull/495) |
-| plugins              | []                 | load plugins to provide extended record functions. [What is plugins?](./docs/recipes/plugin.md) |
+| plugins              | []                 | load plugins to provide extended record functions. [What is plugins?](./docs/recipes/plugin.md)                                                                                               |
 
 #### Privacy
 

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@atlasinc/rrweb-snapshot",
+  "name": "rrweb-snapshot",
   "version": "1.1.19",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rrweb-snapshot",
-  "version": "1.1.19",
+  "name": "@atlasinc/rrweb-snapshot",
+  "version": "1.1.20",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -217,21 +217,15 @@ function buildNode(
           }
         } else {
           // handle internal attributes
-          if (tagName === 'canvas') {
-            if (name === 'rr_dataURL') {
-              const image = document.createElement('img');
-              image.src = value;
-              image.onload = () => {
-                const ctx = (node as HTMLCanvasElement).getContext('2d');
-                if (ctx) {
-                  ctx.drawImage(image, 0, 0, image.width, image.height);
-                }
-              };
-            } else if (name === 'rr_canvasFallbackWidth') {
-              (node as HTMLCanvasElement).style.width = value;
-            } else if (name === 'rr_canvasFallbackHeight') {
-              (node as HTMLCanvasElement).style.height = value;
-            }
+          if (tagName === 'canvas' && name === 'rr_dataURL') {
+            const image = document.createElement('img');
+            image.src = value;
+            image.onload = () => {
+              const ctx = (node as HTMLCanvasElement).getContext('2d');
+              if (ctx) {
+                ctx.drawImage(image, 0, 0, image.width, image.height);
+              }
+            };
           } else if (tagName === 'img' && name === 'rr_dataURL') {
             const image = node as HTMLImageElement;
             if (!image.currentSrc.startsWith('data:')) {
@@ -271,6 +265,18 @@ function buildNode(
             ); // keep this attribute for rrweb to trigger showModal
           }
         }
+      }
+      if (
+        tagName === 'canvas' &&
+        n.attributes.rr_canvasFallbackWidth &&
+        n.attributes.rr_canvasFallbackHeight
+      ) {
+        const canvasStyle = document.createElement('style');
+        const width = n.attributes.rr_canvasFallbackWidth;
+        const height = n.attributes.rr_canvasFallbackHeight;
+
+        canvasStyle.innerText = `:where(canvas) { width: ${width}; height: ${height}; }`;
+        node.appendChild(canvasStyle);
       }
       if (n.isShadowHost) {
         /**

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -272,6 +272,8 @@ function buildNode(
         n.attributes.rr_canvasFallbackHeight
       ) {
         const canvasStyle = document.createElement('style');
+        canvasStyle.setAttribute('rr-canvas-style', '1');
+
         const canvasClass = `canvas-${Math.random().toString(36).substr(2, 9)}`;
         const width = n.attributes.rr_canvasFallbackWidth;
         const height = n.attributes.rr_canvasFallbackHeight;

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -311,7 +311,7 @@ export function buildNodeWithSN(
     map: idNodeMap;
     skipChild?: boolean;
     hackCss: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: INode, id: number) => unknown;
     cache: BuildCache;
   },
 ): INode | null {
@@ -390,7 +390,7 @@ export function buildNodeWithSN(
         node.appendChild(childNode);
       }
       if (afterAppend) {
-        afterAppend(childNode);
+        afterAppend(childNode, childN.id);
       }
     }
   }
@@ -436,7 +436,7 @@ function rebuild(
     doc: Document;
     onVisit?: (node: INode) => unknown;
     hackCss?: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: INode, id: number) => unknown;
     cache: BuildCache;
   },
 ): [Node | null, idNodeMap] {

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -272,10 +272,12 @@ function buildNode(
         n.attributes.rr_canvasFallbackHeight
       ) {
         const canvasStyle = document.createElement('style');
+        const canvasClass = `canvas-${Math.random().toString(36).substr(2, 9)}`;
         const width = n.attributes.rr_canvasFallbackWidth;
         const height = n.attributes.rr_canvasFallbackHeight;
 
-        canvasStyle.innerText = `:where(canvas) { width: ${width}; height: ${height}; }`;
+        canvasStyle.innerText = `:where(canvas.${canvasClass}) { width: ${width}; height: ${height}; }`;
+        node.classList.add(canvasClass);
         node.appendChild(canvasStyle);
       }
       if (n.isShadowHost) {

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -217,15 +217,21 @@ function buildNode(
           }
         } else {
           // handle internal attributes
-          if (tagName === 'canvas' && name === 'rr_dataURL') {
-            const image = document.createElement('img');
-            image.src = value;
-            image.onload = () => {
-              const ctx = (node as HTMLCanvasElement).getContext('2d');
-              if (ctx) {
-                ctx.drawImage(image, 0, 0, image.width, image.height);
-              }
-            };
+          if (tagName === 'canvas') {
+            if (name === 'rr_dataURL') {
+              const image = document.createElement('img');
+              image.src = value;
+              image.onload = () => {
+                const ctx = (node as HTMLCanvasElement).getContext('2d');
+                if (ctx) {
+                  ctx.drawImage(image, 0, 0, image.width, image.height);
+                }
+              };
+            } else if (name === 'rr_canvasFallbackWidth') {
+              (node as HTMLCanvasElement).style.width = value;
+            } else if (name === 'rr_canvasFallbackHeight') {
+              (node as HTMLCanvasElement).style.height = value;
+            }
           } else if (tagName === 'img' && name === 'rr_dataURL') {
             const image = node as HTMLImageElement;
             if (!image.currentSrc.startsWith('data:')) {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -551,31 +551,45 @@ function serializeNode(
         // register what type of dialog is this
         // `modal` or `non-modal`
         // this is used to trigger `showModal()` or `show()` on replay (outside of rrweb-snapshot, in rrweb)
-        (attributes as DialogAttributes).rr_open_mode = (n as HTMLDialogElement).matches('dialog:modal')
+        (attributes as DialogAttributes).rr_open_mode = (n as HTMLDialogElement).matches(
+          'dialog:modal',
+        )
           ? 'modal'
           : 'non-modal';
       }
 
       // canvas image data
-      if (tagName === 'canvas' && recordCanvas) {
-        if ((n as ICanvas).__context === '2d') {
-          // only record this on 2d canvas
-          if (!is2DCanvasBlank(n as HTMLCanvasElement)) {
-            attributes.rr_dataURL = (n as HTMLCanvasElement).toDataURL();
-          }
-        } else if (!('__context' in n)) {
-          // context is unknown, better not call getContext to trigger it
-          const canvasDataURL = (n as HTMLCanvasElement).toDataURL();
+      if (tagName === 'canvas') {
+        const canvas = n as HTMLCanvasElement;
+        const computed = window.getComputedStyle(canvas);
 
-          // create blank canvas of same dimensions
-          const blankCanvas = document.createElement('canvas');
-          blankCanvas.width = (n as HTMLCanvasElement).width;
-          blankCanvas.height = (n as HTMLCanvasElement).height;
-          const blankCanvasDataURL = blankCanvas.toDataURL();
+        if (!canvas.style.width) {
+          attributes.rr_canvasFallbackWidth = computed.width;
+        }
+        if (!canvas.style.height) {
+          attributes.rr_canvasFallbackHeight = computed.height;
+        }
 
-          // no need to save dataURL if it's the same as blank canvas
-          if (canvasDataURL !== blankCanvasDataURL) {
-            attributes.rr_dataURL = canvasDataURL;
+        if (recordCanvas) {
+          if ((n as ICanvas).__context === '2d') {
+            // only record this on 2d canvas
+            if (!is2DCanvasBlank(n as HTMLCanvasElement)) {
+              attributes.rr_dataURL = (n as HTMLCanvasElement).toDataURL();
+            }
+          } else if (!('__context' in n)) {
+            // context is unknown, better not call getContext to trigger it
+            const canvasDataURL = (n as HTMLCanvasElement).toDataURL();
+
+            // create blank canvas of same dimensions
+            const blankCanvas = document.createElement('canvas');
+            blankCanvas.width = (n as HTMLCanvasElement).width;
+            blankCanvas.height = (n as HTMLCanvasElement).height;
+            const blankCanvasDataURL = blankCanvas.toDataURL();
+
+            // no need to save dataURL if it's the same as blank canvas
+            if (canvasDataURL !== blankCanvasDataURL) {
+              attributes.rr_dataURL = canvasDataURL;
+            }
           }
         }
       }

--- a/packages/rrweb-snapshot/src/types.ts
+++ b/packages/rrweb-snapshot/src/types.ts
@@ -88,6 +88,10 @@ export interface INode extends Node {
   __sn_atlas: serializedNodeWithId;
 }
 
+export interface ICanvas extends HTMLCanvasElement {
+  __context: string;
+}
+
 export type idNodeMap = {
   [key: number]: INode;
 };
@@ -125,9 +129,17 @@ export type SlimDOMOptions = Partial<{
   headMetaVerification: boolean;
 }>;
 
+export type DataURLOptions = Partial<{
+  type: string;
+  quality: number;
+}>;
+
 export type MaskTextFn = (text: string) => string;
 export type MaskInputFn = (text: string) => string;
-export type MaskImageFn = (n: HTMLImageElement, attributes: attributes) => attributes;
+export type MaskImageFn = (
+  n: HTMLImageElement,
+  attributes: attributes,
+) => attributes;
 
 export type KeepIframeSrcFn = (src: string) => boolean;
 

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -146,37 +146,41 @@ export function is2DCanvasBlank(canvas: HTMLCanvasElement): boolean {
   if (!ctx) {
     return true;
   }
-  /* SIMPLIFIED */
-
-  return false;
-  /*
   const chunkSize = 50;
 
-  // get chunks of the canvas and check if it is blank
-  for (let x = 0; x < canvas.width; x += chunkSize) {
-    for (let y = 0; y < canvas.height; y += chunkSize) {
-      const getImageData = ctx.getImageData as PatchedGetImageData;
-      const originalGetImageData =
-        ORIGINAL_ATTRIBUTE_NAME in getImageData
-          ? getImageData[ORIGINAL_ATTRIBUTE_NAME]
-          : getImageData;
-      // by getting the canvas in chunks we avoid an expensive
-      // `getImageData` call that retrieves everything
-      // even if we can already tell from the first chunk(s) that
-      // the canvas isn't blank
-      const pixelBuffer = new Uint32Array(
-        originalGetImageData(
-          x,
-          y,
-          Math.min(chunkSize, canvas.width - x),
-          Math.min(chunkSize, canvas.height - y),
-        ).data.buffer,
-      );
-      if (pixelBuffer.some((pixel) => pixel !== 0)) {
-        return false;
+  try {
+    // get chunks of the canvas and check if it is blank
+    for (let x = 0; x < canvas.width; x += chunkSize) {
+      for (let y = 0; y < canvas.height; y += chunkSize) {
+        const getImageData = ctx.getImageData as PatchedGetImageData;
+        const originalGetImageData =
+          ORIGINAL_ATTRIBUTE_NAME in getImageData
+            ? getImageData[ORIGINAL_ATTRIBUTE_NAME]
+            : getImageData;
+        // by getting the canvas in chunks we avoid an expensive
+        // `getImageData` call that retrieves everything
+        // even if we can already tell from the first chunk(s) that
+        // the canvas isn't blank
+        const pixelBuffer = new Uint32Array(
+          originalGetImageData(
+            x,
+            y,
+            Math.min(chunkSize, canvas.width - x),
+            Math.min(chunkSize, canvas.height - y),
+          ).data.buffer,
+        );
+        if (pixelBuffer.some((pixel) => pixel !== 0)) {
+          return false;
+        }
       }
     }
+  } catch (e) {
+    console.warn(e);
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases
+    // getImageData may be blocked by CORS policy
+    // we'll assume that the canvas is not blank
+    return false;
   }
+
   return true;
-   */
 }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -135,3 +135,48 @@ export function maskImage({
     alt,
   };
 }
+
+const ORIGINAL_ATTRIBUTE_NAME = '__rrweb_original__';
+type PatchedGetImageData = {
+  [ORIGINAL_ATTRIBUTE_NAME]: CanvasImageData['getImageData'];
+} & CanvasImageData['getImageData'];
+
+export function is2DCanvasBlank(canvas: HTMLCanvasElement): boolean {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return true;
+  }
+  /* SIMPLIFIED */
+
+  return false;
+  /*
+  const chunkSize = 50;
+
+  // get chunks of the canvas and check if it is blank
+  for (let x = 0; x < canvas.width; x += chunkSize) {
+    for (let y = 0; y < canvas.height; y += chunkSize) {
+      const getImageData = ctx.getImageData as PatchedGetImageData;
+      const originalGetImageData =
+        ORIGINAL_ATTRIBUTE_NAME in getImageData
+          ? getImageData[ORIGINAL_ATTRIBUTE_NAME]
+          : getImageData;
+      // by getting the canvas in chunks we avoid an expensive
+      // `getImageData` call that retrieves everything
+      // even if we can already tell from the first chunk(s) that
+      // the canvas isn't blank
+      const pixelBuffer = new Uint32Array(
+        originalGetImageData(
+          x,
+          y,
+          Math.min(chunkSize, canvas.width - x),
+          Math.min(chunkSize, canvas.height - y),
+        ).data.buffer,
+      );
+      if (pixelBuffer.some((pixel) => pixel !== 0)) {
+        return false;
+      }
+    }
+  }
+  return true;
+   */
+}

--- a/packages/rrweb-snapshot/typings/rebuild.d.ts
+++ b/packages/rrweb-snapshot/typings/rebuild.d.ts
@@ -6,14 +6,14 @@ export declare function buildNodeWithSN(n: serializedNodeWithId, options: {
     map: idNodeMap;
     skipChild?: boolean;
     hackCss: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: INode, id: number) => unknown;
     cache: BuildCache;
 }): INode | null;
 declare function rebuild(n: serializedNodeWithId, options: {
     doc: Document;
     onVisit?: (node: INode) => unknown;
     hackCss?: boolean;
-    afterAppend?: (n: INode) => unknown;
+    afterAppend?: (n: INode, id: number) => unknown;
     cache: BuildCache;
 }): [Node | null, idNodeMap];
 export default rebuild;

--- a/packages/rrweb-snapshot/typings/snapshot.d.ts
+++ b/packages/rrweb-snapshot/typings/snapshot.d.ts
@@ -1,4 +1,4 @@
-import { serializedNodeWithId, INode, idNodeMap, MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn, MaskImageFn } from './types';
+import { serializedNodeWithId, INode, idNodeMap, MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn, MaskImageFn, DataURLOptions } from './types';
 export declare const IGNORED_NODE = -2;
 export declare function absoluteToStylesheet(cssText: string | null, href: string): string;
 export declare function absoluteToDoc(doc: Document, attributeValue: string): string;
@@ -39,6 +39,7 @@ declare function snapshot(n: Document, options?: {
     maskInputFn?: MaskTextFn;
     maskImageFn?: MaskImageFn;
     slimDOM?: boolean | SlimDOMOptions;
+    dataURLOptions?: DataURLOptions;
     inlineImages?: boolean;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;

--- a/packages/rrweb-snapshot/typings/types.d.ts
+++ b/packages/rrweb-snapshot/typings/types.d.ts
@@ -59,6 +59,9 @@ export declare type DialogAttributes = {
 export interface INode extends Node {
     __sn_atlas: serializedNodeWithId;
 }
+export interface ICanvas extends HTMLCanvasElement {
+    __context: string;
+}
 export declare type idNodeMap = {
     [key: number]: INode;
 };
@@ -91,6 +94,10 @@ export declare type SlimDOMOptions = Partial<{
     headMetaHttpEquiv: boolean;
     headMetaAuthorship: boolean;
     headMetaVerification: boolean;
+}>;
+export declare type DataURLOptions = Partial<{
+    type: string;
+    quality: number;
 }>;
 export declare type MaskTextFn = (text: string) => string;
 export declare type MaskInputFn = (text: string) => string;

--- a/packages/rrweb-snapshot/typings/utils.d.ts
+++ b/packages/rrweb-snapshot/typings/utils.d.ts
@@ -18,3 +18,4 @@ export declare function maskImage({ n, attributes, maskImageFn, }: {
     attributes: attributes;
     maskImageFn?: MaskImageFn;
 }): attributes;
+export declare function is2DCanvasBlank(canvas: HTMLCanvasElement): boolean;

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@atlasinc/rrweb",
+  "name": "rrweb",
   "version": "1.1.23",
   "description": "record and replay the web",
   "scripts": {
@@ -41,14 +41,14 @@
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^7.0.0",
-    "@rollup/plugin-typescript": "^8.2.5",
+    "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/chai": "^4.1.6",
     "@types/css-font-loading-module": "0.0.7",
     "@types/inquirer": "0.0.43",
     "@types/jest": "^27.0.2",
     "@types/jsdom": "^16.2.12",
     "@types/node": "^12.20.16",
+    "@types/offscreencanvas": "^2019.6.4",
     "@types/prettier": "^2.3.2",
     "@types/puppeteer": "^5.4.3",
     "cross-env": "^5.2.0",
@@ -61,10 +61,12 @@
     "jsdom-global": "^3.0.2",
     "prettier": "2.2.1",
     "puppeteer": "^9.1.1",
-    "rollup": "^2.45.2",
+    "rollup": "^2.68.0",
     "rollup-plugin-postcss": "^3.1.1",
-    "rollup-plugin-rename-node-modules": "^1.1.0",
+    "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-typescript2": "^0.31.2",
+    "rollup-plugin-web-worker-loader": "^1.6.1",
     "ts-jest": "^27.0.5",
     "ts-node": "^7.0.1",
     "tslib": "^1.9.3",
@@ -73,6 +75,7 @@
   },
   "dependencies": {
     "@xstate/fsm": "^1.4.0",
+    "base64-arraybuffer": "^1.0.1",
     "fflate": "^0.4.4",
     "mitt": "^1.1.3",
     "rrweb-snapshot": "npm:@atlasinc/rrweb-snapshot@1.1.19"

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rrweb",
-  "version": "1.1.23",
+  "name": "@atlasinc/rrweb",
+  "version": "1.1.24",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -101,7 +101,9 @@ let configs = [];
 for (const c of baseConfigs) {
   const basePlugins = [
     resolve({ browser: true }),
-    webWorkerLoader(),
+    webWorkerLoader({
+      targetPlatform: 'browser',
+    }),
     typescript(),
   ];
   const plugins = basePlugins.concat(

--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -1,8 +1,9 @@
-import typescript from '@rollup/plugin-typescript';
+import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 import postcss from 'rollup-plugin-postcss';
 import renameNodeModules from 'rollup-plugin-rename-node-modules';
+import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import pkg from './package.json';
 
 function toRecordPath(path) {
@@ -45,6 +46,13 @@ function toMinPath(path) {
 }
 
 const baseConfigs = [
+  // all in one
+  {
+    input: './src/entries/all.ts',
+    name: 'rrweb',
+    pathFn: toAllPath,
+    esm: true,
+  },
   // record only
   {
     input: './src/record/index.ts',
@@ -75,13 +83,6 @@ const baseConfigs = [
     name: 'rrweb',
     pathFn: (p) => p,
   },
-  // all in one
-  {
-    input: './src/entries/all.ts',
-    name: 'rrweb',
-    pathFn: toAllPath,
-    esm: true,
-  },
   // plugins
   {
     input: './src/plugins/console/record/index.ts',
@@ -100,10 +101,8 @@ let configs = [];
 for (const c of baseConfigs) {
   const basePlugins = [
     resolve({ browser: true }),
-    typescript({
-      // a trick to avoid @rollup/plugin-typescript error
-      outDir: 'es/rrweb',
-    }),
+    webWorkerLoader(),
+    typescript(),
   ];
   const plugins = basePlugins.concat(
     postcss({
@@ -190,6 +189,7 @@ if (process.env.BROWSER_ONLY) {
   for (const c of browserOnlyBaseConfigs) {
     const plugins = [
       resolve({ browser: true }),
+      webWorkerLoader(),
       typescript({
         outDir: null,
       }),

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -1,8 +1,10 @@
 import record from './record';
 import { Replayer } from './replay';
+import canvasMutation from './replay/canvas';
 import { _mirror } from './utils';
 import * as utils from './utils';
 import * as replayUtils from './replay/utils';
+import { CanvasReplayerPlugin } from './plugins/replay-canvas-plugin/plugin';
 
 export {
   EventType,
@@ -22,4 +24,6 @@ export {
   _mirror as mirror,
   utils,
   replayUtils,
+  canvasMutation,
+  CanvasReplayerPlugin,
 };

--- a/packages/rrweb/src/plugins/replay-canvas-plugin/debounce.ts
+++ b/packages/rrweb/src/plugins/replay-canvas-plugin/debounce.ts
@@ -1,0 +1,29 @@
+export default function debounce<T extends (...args: Array<unknown>) => void>(
+  func: T,
+  wait: number,
+  immediate?: boolean
+): (this: ThisParameterType<T>, ...args: Parameters<T>) => void {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  return function (this: ThisParameterType<T>, ...args: Parameters<T>): void {
+    const context = this;
+
+    const later = () => {
+      timeout = null;
+      if (!immediate) {
+        func.apply(context, args);
+      }
+    };
+
+    const callNow = immediate && timeout === null;
+
+    if (timeout !== null) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(later, wait);
+
+    if (callNow) {
+      func.apply(context, args);
+    }
+  };
+}

--- a/packages/rrweb/src/plugins/replay-canvas-plugin/deserialize-canvas-args.ts
+++ b/packages/rrweb/src/plugins/replay-canvas-plugin/deserialize-canvas-args.ts
@@ -1,0 +1,92 @@
+import { Replayer } from '../../replay';
+import { CanvasArg } from '../../types';
+
+type GLVarMap = Map<string, any[]>;
+type CanvasContexts =
+    | CanvasRenderingContext2D
+    | WebGLRenderingContext
+    | WebGL2RenderingContext;
+const webGLVarMap: Map<CanvasContexts, GLVarMap> = new Map();
+
+const variableListFor = (ctx: CanvasContexts, ctor: string): any[] => {
+    let contextMap = webGLVarMap.get(ctx);
+    if (!contextMap) {
+        contextMap = new Map();
+        webGLVarMap.set(ctx, contextMap);
+    }
+    if (!contextMap.has(ctor)) {
+        contextMap.set(ctor, []);
+    }
+
+    return contextMap.get(ctor) as any[];
+};
+
+const base64ArrayBuffer = (encodedString: string): ArrayBuffer => {
+    const data = base64ToUint8Array(encodedString);
+    return data.buffer;
+};
+
+const base64ToUint8Array = (encodedString: string): Uint8Array => {
+    const binString = atob(encodedString);
+    const data = new Uint8Array(binString.length);
+    for (let i = 0; i < binString.length; i++) {
+        data[i] = binString.charCodeAt(i);
+    }
+    return data;
+};
+
+export const deserializeCanvasArg = (
+    imageMap: Replayer['imageMap'],
+    ctx: CanvasContexts | null,
+    preload?: {
+        isUnchanged: boolean;
+    },
+): ((arg: CanvasArg) => Promise<any>) => {
+    return async (arg: CanvasArg): Promise<any> => {
+        if (arg && typeof arg === 'object' && 'rr_type' in arg) {
+            if (preload) {
+                preload.isUnchanged = false;
+            }
+            if (arg.rr_type === 'ImageBitmap' && 'args' in arg) {
+                const args = await deserializeCanvasArg(
+                    imageMap,
+                    ctx,
+                    preload,
+                )(arg.args);
+                // eslint-disable-next-line prefer-spread
+                return await createImageBitmap.apply(null, args);
+            }
+            if ('index' in arg) {
+                if (preload || ctx === null) {
+                    return arg;
+                }
+                const { rr_type: name, index } = arg;
+                return variableListFor(ctx, name)[index];
+            }
+            if ('args' in arg) {
+                return arg;
+            }
+            if ('base64' in arg) {
+                return base64ArrayBuffer(arg.base64);
+            }
+            if ('src' in arg) {
+                return arg;
+            }
+            if ('data' in arg && arg.rr_type === 'Blob') {
+                const blobContents = await Promise.all(
+                    arg.data.map(deserializeCanvasArg(imageMap, ctx, preload)),
+                );
+                const blob = new Blob(blobContents, {
+                    type: arg.type,
+                });
+                return blob;
+            }
+        } else if (Array.isArray(arg)) {
+            const result = await Promise.all(
+                arg.map(deserializeCanvasArg(imageMap, ctx, preload)),
+            );
+            return result;
+        }
+        return arg;
+    };
+};

--- a/packages/rrweb/src/plugins/replay-canvas-plugin/deserialize-canvas-args.ts
+++ b/packages/rrweb/src/plugins/replay-canvas-plugin/deserialize-canvas-args.ts
@@ -53,7 +53,6 @@ export const deserializeCanvasArg = (
                     ctx,
                     preload,
                 )(arg.args);
-                // eslint-disable-next-line prefer-spread
                 return await createImageBitmap.apply(null, args);
             }
             if ('index' in arg) {

--- a/packages/rrweb/src/plugins/replay-canvas-plugin/plugin.ts
+++ b/packages/rrweb/src/plugins/replay-canvas-plugin/plugin.ts
@@ -1,0 +1,379 @@
+import type {
+  CanvasArg,
+  canvasMutationData,
+  canvasMutationParam,
+  eventWithTime,
+  ReplayPlugin,
+} from '../../types';
+
+import { deserializeCanvasArg } from './deserialize-canvas-args';
+import { EventType, IncrementalSource } from '../../types';
+import { Replayer } from '../../replay';
+import debounce from './debounce';
+import canvasMutation from '../../replay/canvas';
+
+type CanvasEventWithTime = eventWithTime & {
+  data: canvasMutationData;
+  type: EventType.IncrementalSnapshot;
+};
+
+function isCanvasMutationEvent(e: eventWithTime): e is CanvasEventWithTime {
+  return (
+    e.type === EventType.IncrementalSnapshot &&
+    e.data.source === IncrementalSource.CanvasMutation
+  );
+}
+
+class InvalidCanvasNodeError extends Error {}
+
+/**
+ * Find the lowest matching index for event
+ */
+function findIndex(
+  arr: eventWithTime[],
+  event?: eventWithTime,
+  optionalStart?: number,
+  optionalEnd?: number,
+): number {
+  if (!event) {
+    return -1;
+  }
+
+  const start = optionalStart ?? 0;
+  const end = optionalEnd ?? arr.length - 1;
+
+  if (start > end) {
+    return end;
+  }
+
+  const mid = Math.floor((start + end) / 2);
+
+  // Search lower half
+  if (event.timestamp <= arr[mid].timestamp) {
+    return findIndex(arr, event, start, mid - 1);
+  }
+
+  // Search top half
+  return findIndex(arr, event, mid + 1, end);
+}
+
+/**
+ * Plugin which:
+ *   - preloads a small amount of canvas events to improve playback
+ *   - applies the canvas draw commands to a canvas outside of rrweb iframe
+ *    - copies outside canvas to iframe canvas
+ *    - this avoids having to remove iframe sandbox
+ */
+export function CanvasReplayerPlugin(rrwebReplayer: Replayer | null): ReplayPlugin {
+  const PRELOAD_SIZE = 50;
+  const BUFFER_TIME = 20_000;
+  const canvases = new Map<number, HTMLCanvasElement>();
+  const containers = new Map<number, HTMLImageElement>();
+  const imageMap = new Map<CanvasEventWithTime | string, HTMLImageElement>();
+  // `canvasEventMap` can not be assumed to be sorted because it is ordered by
+  // insertion order and insertions will not happen in a linear timeline due to
+  // the ability to jump around the playback
+  const canvasEventMap = new Map<CanvasEventWithTime, canvasMutationParam>();
+  const getCanvasMutationEvents = (): CanvasEventWithTime[] =>
+    rrwebReplayer?.service.state.context.events.filter(isCanvasMutationEvent) || [];
+  // `deserializeAndPreloadCanvasEvents()` is async and `preload()` can be
+  // called before the previous call finishes, so we use this Set to determine
+  // if a deserialization of an event is in progress so that it can be skipped if so.
+  const preloadQueue = new Set<CanvasEventWithTime>();
+  const eventsToPrune: eventWithTime[] = [];
+  // In the case where replay is not started and user seeks, `handler` can be
+  // called before the DOM is fully built. This means that nodes do not yet
+  // exist in DOM mirror. We need to replay these events when `onBuild` is
+  // called.
+  const handleQueue = new Map<number, [CanvasEventWithTime, Replayer]>();
+
+  // This is a pointer to the index of the next event that will need to be
+  // preloaded. Most of the time the recording plays sequentially, so we do not
+  // need to re-iterate through the events list.
+  //
+  // If this value is -1, then it means there is no next preload index and we
+  // should search (`findIndex`) the events list for the index. This happens
+  // when the user jumps around the recording.
+  let nextPreloadIndex = 0;
+
+  /**
+   * Prune events that are more than <20> seconds away (both older and newer) than given event.
+   *
+   * 20 seconds is used as the buffer because our UI's "go back 10 seconds".
+   */
+  function prune(event: eventWithTime): void {
+    while (eventsToPrune.length) {
+      // Peek top of queue and see if event should be pruned, otherwise we can break out of the loop
+      if (
+        Math.abs(event.timestamp - eventsToPrune[0].timestamp) <= BUFFER_TIME &&
+        eventsToPrune.length <= PRELOAD_SIZE
+      ) {
+        break;
+      }
+
+      const eventToPrune = eventsToPrune.shift();
+      if (
+        eventToPrune &&
+        isCanvasMutationEvent(eventToPrune) &&
+        canvasEventMap.has(eventToPrune)
+      ) {
+        canvasEventMap.delete(eventToPrune);
+      }
+    }
+
+    // TODO: as a failsafe, we could apply same logic to canvasEventMap if it goes over a certain size
+
+    eventsToPrune.push(event);
+  }
+
+  async function deserializeAndPreloadCanvasEvents(
+    data: canvasMutationData,
+    event: CanvasEventWithTime,
+  ): Promise<void> {
+    if (!canvasEventMap.has(event)) {
+      const status = {
+        isUnchanged: true,
+      };
+      if ('commands' in data) {
+        const commands = await Promise.all(
+          data.commands.map(async (c) => {
+            const args = await Promise.all(
+              (c.args as CanvasArg[]).map(
+                deserializeCanvasArg(imageMap, null, status),
+              ),
+            );
+            return { ...c, args };
+          }),
+        );
+        if (status.isUnchanged === false) {
+          canvasEventMap.set(event, { ...data, commands });
+        }
+      } else {
+        const args = await Promise.all(
+          (data.args as CanvasArg[]).map(
+            deserializeCanvasArg(imageMap, null, status),
+          ),
+        );
+        if (status.isUnchanged === false) {
+          canvasEventMap.set(event, { ...data, args });
+        }
+      }
+    }
+  }
+
+  /**
+   * Clone canvas node, change parent document of node to current document, and
+   * insert an image element to original node (i.e. canvas inside of iframe).
+   *
+   * The image element is saved to `containers` map, which will later get
+   * written to when replay is being played.
+   */
+  function cloneCanvas(id: number, node: HTMLCanvasElement) {
+    const cloneNode = node.cloneNode() as HTMLCanvasElement;
+    canvases.set(id, cloneNode);
+    document.adoptNode(cloneNode);
+    return cloneNode;
+  }
+
+  async function preload(
+    currentEvent?: eventWithTime,
+    preloadCount = PRELOAD_SIZE,
+  ) {
+    const foundIndex =
+      nextPreloadIndex > -1
+        ? nextPreloadIndex
+        : findIndex(getCanvasMutationEvents(), currentEvent);
+    const startIndex = foundIndex > -1 ? foundIndex : 0;
+    const eventsToPreload = getCanvasMutationEvents()
+      .slice(startIndex, startIndex + preloadCount)
+      .filter(
+        ({ timestamp }) =>
+          !currentEvent || timestamp - currentEvent.timestamp <= BUFFER_TIME,
+      );
+
+    nextPreloadIndex =
+      nextPreloadIndex > -1 ? nextPreloadIndex + 1 : startIndex;
+
+    for (const event of eventsToPreload) {
+      if (!preloadQueue.has(event) && !canvasEventMap.has(event)) {
+        preloadQueue.add(event);
+        // Deserialize and preload an event serially, otherwise for large event
+        // counts, this can crash the browser
+        await deserializeAndPreloadCanvasEvents(
+          event.data as canvasMutationData,
+          event,
+        );
+        preloadQueue.delete(event);
+      }
+    }
+  }
+
+  // Debounce so that `processEvent` is not called immediately. We want to only
+  // process the most recent event, otherwise it will look like the canvas is
+  // animating when we seek throughout replay.
+  //
+  // `handleQueue` is really a map of canvas id -> most recent canvas mutation
+  // event for all canvas mutation events before the current replay time
+  const debouncedProcessQueuedEvents = debounce(
+    function processQueuedEvents() {
+      const canvasIds = Array.from(canvases.keys());
+      const queuedEventIds = Array.from(handleQueue.keys());
+      const queuedEventIdsSet = new Set(queuedEventIds);
+      const unusedCanvases = canvasIds.filter(
+        (id) => !queuedEventIdsSet.has(id),
+      );
+
+      // Compare the canvas ids from canvas mutation events against existing
+      // canvases and remove the canvas snapshot for previously drawn to
+      // canvases that do not currently exist in this new point of time
+      unusedCanvases.forEach((id) => {
+        const el = containers.get(id);
+        if (el) {
+          el.src = '';
+        }
+      });
+
+      // Find all canvases with an event that needs to process
+      Array.from(handleQueue.entries()).forEach(async ([id, [e, replayer]]) => {
+        try {
+          await processEvent(e, { replayer });
+          handleQueue.delete(id);
+        } catch (err) {
+          handleProcessEventError(err);
+        }
+      });
+    },
+    250,
+  );
+
+  /**
+   * In the case where mirror DOM is built, we only want to process the most
+   * recent sync event, otherwise the playback will look like it's playing if
+   * we process all events.
+   */
+  function processEventSync(
+    e: eventWithTime,
+    { replayer }: { replayer: Replayer },
+  ) {
+    // We want to only process the most recent sync CanvasMutationEvent
+    if (isCanvasMutationEvent(e)) {
+      handleQueue.set(e.data.id, [e, replayer]);
+    }
+    debouncedProcessQueuedEvents();
+  }
+
+  /**
+   * Processes canvas mutation events
+   */
+  async function processEvent(
+    e: CanvasEventWithTime,
+    { replayer }: { replayer: Replayer },
+  ) {
+    preload(e);
+
+    const source = replayer.getMirror().getNode(e.data.id);
+    const target =
+      canvases.get(e.data.id) ||
+      (source &&
+        cloneCanvas(e.data.id, (source as unknown) as HTMLCanvasElement));
+
+    if (!target) {
+      throw new InvalidCanvasNodeError('No canvas found for id');
+    }
+
+    await canvasMutation({
+      event: e,
+      mutation: e.data,
+      target,
+      imageMap,
+      canvasEventMap,
+      errorHandler: handleProcessEventError,
+    });
+
+    const img = containers.get(e.data.id);
+    if (img) {
+      img.src = target.toDataURL();
+      img.className = 'rrweb-snapshot-canvas';
+      img.style.width = 'auto';
+      img.style.height = 'auto';
+      img.style.maxWidth = '100%';
+      img.style.maxHeight = '100%';
+    }
+
+    prune(e);
+  }
+
+  preload();
+
+  return {
+    /**
+     * When document is first built, we want to preload canvas events. After a
+     * `canvas` element is built (in rrweb), insert an image element which will
+     * be used to mirror the drawn canvas.
+     */
+    onBuild: (node, { id }) => {
+      if (!node) {
+        return;
+      }
+
+      if (node.nodeName === 'CANVAS' && node.nodeType === 1) {
+        // Add new image container that will be written to
+        const el = containers.get(id) || document.createElement('img');
+        (node as HTMLCanvasElement).appendChild(el);
+        containers.set(id, el);
+      }
+
+      // See comments at definition of `handleQueue`
+      const queueItem = handleQueue.get(id);
+      handleQueue.delete(id);
+      if (!queueItem) {
+        return;
+      }
+      const [event, replayer] = queueItem;
+      processEvent(event, { replayer }).catch(handleProcessEventError);
+    },
+
+    /**
+     * Mutate canvas outside of iframe, then export the canvas as an image, and
+     * draw inside of the image el inside of replay canvas.
+     */
+    handler: (
+      e: eventWithTime,
+      isSync: boolean,
+      { replayer }: { replayer: Replayer },
+    ) => {
+      const isCanvas = isCanvasMutationEvent(e);
+
+      // isSync = true means it is fast forwarding vs playing
+      // nothing to do when fast forwarding since canvas mutations for us are
+      // image snapshots and do not depend on past events
+      if (isSync) {
+        // Set this to -1 to indicate that we will need to search
+        // `canvasMutationEvents` for starting point of preloading
+        //
+        // Only do this when isSync is true, meaning there was a seek, since we
+        // don't know where next index is
+        nextPreloadIndex = -1;
+        processEventSync(e, { replayer });
+        prune(e);
+        return;
+      }
+
+      if (!isCanvas) {
+        // Otherwise, not `isSync` and not canvas, only need to prune
+        prune(e);
+
+        return;
+      }
+
+      processEvent(e as CanvasEventWithTime, { replayer }).catch(handleProcessEventError);
+    },
+  };
+}
+
+function handleProcessEventError(err: unknown) {
+  if (err instanceof InvalidCanvasNodeError) {
+    console.warn(err);
+    return;
+  }
+}

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -18,10 +18,12 @@ import {
   listenerHandler,
   mutationCallbackParam,
   scrollCallback,
+  canvasMutationParam,
 } from '../types';
 import { IframeManager } from './iframe-manager';
 import { ShadowDomManager } from './shadow-dom-manager';
 import { MutationRateLimiter } from './mutation-rate-limiter';
+import { CanvasManager } from './observers/canvas/canvas-manager';
 
 function wrapEvent(e: event): eventWithTime {
   return {
@@ -59,6 +61,7 @@ function record<T = eventWithTime>(
     hooks,
     packFn,
     sampling = {},
+    dataURLOptions = {},
     mousemoveWait,
     recordCanvas = false,
     userTriggeredOnInput = false,
@@ -68,6 +71,7 @@ function record<T = eventWithTime>(
     keepIframeSrcFn = () => false,
     mutationRateLimiterOptions,
   } = options;
+  console.log('INSIDE RECORD! ==>');
   // runtime checks for user options
   if (!emit) {
     throw new Error('emit function is required');
@@ -202,8 +206,30 @@ function record<T = eventWithTime>(
       }),
     );
 
+  const wrappedCanvasMutationEmit = (p: canvasMutationParam) =>
+    wrappedEmit(
+      wrapEvent({
+        type: EventType.IncrementalSnapshot,
+        data: {
+          source: IncrementalSource.CanvasMutation,
+          ...p,
+        },
+      }),
+    );
+
   const iframeManager = new IframeManager({
     mutationCb: wrappedMutationEmit,
+  });
+
+  const canvasManager = new CanvasManager({
+    recordCanvas,
+    mutationCb: wrappedCanvasMutationEmit,
+    win: window,
+    blockClass,
+    blockSelector,
+    mirror,
+    sampling: sampling.canvas,
+    dataURLOptions,
   });
 
   const shadowDomManager = new ShadowDomManager({
@@ -217,6 +243,7 @@ function record<T = eventWithTime>(
       maskAll,
       inlineStylesheet,
       maskInputOptions,
+      dataURLOptions,
       maskTextFn,
       maskInputFn,
       maskImageFn,
@@ -225,6 +252,7 @@ function record<T = eventWithTime>(
       sampling,
       slimDOMOptions,
       iframeManager,
+      canvasManager,
     },
     mirror,
   });
@@ -257,6 +285,7 @@ function record<T = eventWithTime>(
       maskTextFn,
       maskImageFn,
       slimDOM: slimDOMOptions,
+      dataURLOptions,
       recordCanvas,
       inlineImages,
       onSerialize: (n) => {
@@ -393,16 +422,7 @@ function record<T = eventWithTime>(
                 },
               }),
             ),
-          canvasMutationCb: (p) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.CanvasMutation,
-                  ...p,
-                },
-              }),
-            ),
+          canvasMutationCb: wrappedCanvasMutationEmit,
           fontCb: (p) =>
             wrappedEmit(
               wrapEvent({
@@ -431,9 +451,11 @@ function record<T = eventWithTime>(
           maskImageFn,
           blockSelector,
           slimDOMOptions,
+          dataURLOptions,
           mirror,
           iframeManager,
           shadowDomManager,
+          canvasManager,
           plugins:
             plugins?.map((p) => ({
               observer: p.observer,

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -71,7 +71,6 @@ function record<T = eventWithTime>(
     keepIframeSrcFn = () => false,
     mutationRateLimiterOptions,
   } = options;
-  console.log('INSIDE RECORD! ==>');
   // runtime checks for user options
   if (!emit) {
     throw new Error('emit function is required');

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -12,6 +12,7 @@ import {
   MaskTextFn,
   MaskInputFn,
   MaskImageFn,
+  DataURLOptions,
 } from 'rrweb-snapshot';
 import {
   mutationRecord,
@@ -33,6 +34,7 @@ import {
   hasShadowRoot,
 } from '../utils';
 import { IframeManager } from './iframe-manager';
+import { CanvasManager } from './observers/canvas/canvas-manager';
 import { ShadowDomManager } from './shadow-dom-manager';
 
 type DoubleLinkedListNode = {
@@ -178,11 +180,13 @@ export default class MutationBuffer {
   private recordCanvas: boolean;
   private inlineImages: boolean;
   private slimDOMOptions: SlimDOMOptions;
+  private dataURLOptions: DataURLOptions;
   private doc: Document;
 
   private mirror: Mirror;
   private iframeManager: IframeManager;
   private shadowDomManager: ShadowDomManager;
+  private canvasManager: CanvasManager;
 
   public init(
     cb: mutationCallBack,
@@ -199,10 +203,12 @@ export default class MutationBuffer {
     recordCanvas: boolean,
     inlineImages: boolean,
     slimDOMOptions: SlimDOMOptions,
+    dataURLOptions: DataURLOptions,
     doc: Document,
     mirror: Mirror,
     iframeManager: IframeManager,
     shadowDomManager: ShadowDomManager,
+    canvasManager: CanvasManager,
   ) {
     this.blockClass = blockClass;
     this.blockSelector = blockSelector;
@@ -222,14 +228,18 @@ export default class MutationBuffer {
     this.mirror = mirror;
     this.iframeManager = iframeManager;
     this.shadowDomManager = shadowDomManager;
+    this.canvasManager = canvasManager;
+    this.dataURLOptions = dataURLOptions;
   }
 
   public freeze() {
     this.frozen = true;
+    this.canvasManager.freeze();
   }
 
   public unfreeze() {
     this.frozen = false;
+    this.canvasManager.unfreeze();
     this.emit();
   }
 
@@ -239,16 +249,22 @@ export default class MutationBuffer {
 
   public lock() {
     this.locked = true;
+    this.canvasManager.lock();
   }
 
   public unlock() {
     this.locked = false;
+    this.canvasManager.unlock();
     this.emit();
   }
 
+  public reset() {
+    this.canvasManager.reset();
+  }
+
   public processMutations = (mutations: mutationRecord[]) => {
-    mutations.forEach(this.processMutation);
-    this.emit();
+    mutations.forEach(this.processMutation); // adds mutations to the buffer
+    this.emit(); // clears buffer if not locked/frozen
   };
 
   public emit = () => {

--- a/packages/rrweb/src/record/observers/canvas/2d.ts
+++ b/packages/rrweb/src/record/observers/canvas/2d.ts
@@ -1,0 +1,82 @@
+import {
+  blockClass,
+  CanvasContext,
+  canvasManagerMutationCallback,
+  IWindow,
+  listenerHandler,
+} from '../../../types';
+import { hookSetter, isBlocked, patch } from '../../../utils';
+import { serializeArgs } from './serialize-args';
+
+export default function initCanvas2DMutationObserver(
+  cb: canvasManagerMutationCallback,
+  win: IWindow,
+  blockClass: blockClass,
+  blockSelector: string | null,
+): listenerHandler {
+  const handlers: listenerHandler[] = [];
+  const props2D = Object.getOwnPropertyNames(
+    win.CanvasRenderingContext2D.prototype,
+  );
+  for (const prop of props2D) {
+    try {
+      if (
+        typeof win.CanvasRenderingContext2D.prototype[
+          prop as keyof CanvasRenderingContext2D
+        ] !== 'function'
+      ) {
+        continue;
+      }
+      const restoreHandler = patch(
+        win.CanvasRenderingContext2D.prototype,
+        prop,
+        function (
+          original: (
+            this: CanvasRenderingContext2D,
+            ...args: unknown[]
+          ) => void,
+        ) {
+          return function (
+            this: CanvasRenderingContext2D,
+            ...args: Array<unknown>
+          ) {
+            if (!isBlocked(this.canvas, blockClass)) {
+              // Using setTimeout as toDataURL can be heavy
+              // and we'd rather not block the main thread
+              setTimeout(() => {
+                const recordArgs = serializeArgs(args, win, this);
+                cb(this.canvas, {
+                  type: CanvasContext['2D'],
+                  property: prop,
+                  args: recordArgs,
+                });
+              }, 0);
+            }
+            return original.apply(this, args);
+          };
+        },
+      );
+      handlers.push(restoreHandler);
+    } catch {
+      const hookHandler = hookSetter<CanvasRenderingContext2D>(
+        win.CanvasRenderingContext2D.prototype,
+        prop,
+        {
+          set(v) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+            cb(this.canvas, {
+              type: CanvasContext['2D'],
+              property: prop,
+              args: [v],
+              setter: true,
+            });
+          },
+        },
+      );
+      handlers.push(hookHandler);
+    }
+  }
+  return () => {
+    handlers.forEach((h) => h());
+  };
+}

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -1,0 +1,319 @@
+import type { ICanvas, DataURLOptions, INode } from 'rrweb-snapshot';
+import {
+  blockClass,
+  canvasManagerMutationCallback,
+  canvasMutationCallback,
+  canvasMutationCommand,
+  canvasMutationWithType,
+  IWindow,
+  listenerHandler,
+  CanvasArg,
+  CanvasContext,
+  Mirror,
+} from '../../../types';
+import { isBlocked } from '../../../utils';
+import initCanvas2DMutationObserver from './2d';
+import initCanvasContextObserver from './canvas';
+import initCanvasWebGLMutationObserver from './webgl';
+import ImageBitmapDataURLWorker from 'web-worker:../../workers/image-bitmap-data-url-worker.ts';
+import { ImageBitmapDataURLRequestWorker } from '../../workers/image-bitmap-data-url-worker';
+
+export type RafStamps = { latestId: number; invokeId: number | null };
+
+type pendingCanvasMutationsMap = Map<
+  HTMLCanvasElement,
+  canvasMutationWithType[]
+>;
+
+export class CanvasManager {
+  private pendingCanvasMutations: pendingCanvasMutationsMap = new Map();
+  private rafStamps: RafStamps = { latestId: 0, invokeId: null };
+  private mirror: Mirror;
+
+  private mutationCb: canvasMutationCallback;
+  private resetObservers?: listenerHandler;
+  private frozen = false;
+  private locked = false;
+
+  public reset() {
+    this.pendingCanvasMutations.clear();
+    this.resetObservers && this.resetObservers();
+  }
+
+  public freeze() {
+    this.frozen = true;
+  }
+
+  public unfreeze() {
+    this.frozen = false;
+  }
+
+  public lock() {
+    this.locked = true;
+  }
+
+  public unlock() {
+    this.locked = false;
+  }
+
+  constructor(options: {
+    recordCanvas: boolean;
+    mutationCb: canvasMutationCallback;
+    win: IWindow;
+    blockClass: blockClass;
+    blockSelector: string | null;
+    mirror: Mirror;
+    sampling?: 'all' | number;
+    dataURLOptions: DataURLOptions;
+  }) {
+    const {
+      sampling = 'all',
+      win,
+      blockClass,
+      blockSelector,
+      recordCanvas,
+      dataURLOptions,
+    } = options;
+    console.log('recordCanvas ====>', recordCanvas);
+    this.mutationCb = options.mutationCb;
+    this.mirror = options.mirror;
+
+    if (recordCanvas && sampling === 'all')
+      this.initCanvasMutationObserver(win, blockClass, blockSelector);
+    if (recordCanvas && typeof sampling === 'number') {
+      this.initCanvasFPSObserver(sampling, win, blockClass, blockSelector, {
+        dataURLOptions,
+      });
+    }
+  }
+
+  private processMutation: canvasManagerMutationCallback = (
+    target,
+    mutation,
+  ) => {
+    const newFrame =
+      this.rafStamps.invokeId &&
+      this.rafStamps.latestId !== this.rafStamps.invokeId;
+    if (newFrame || !this.rafStamps.invokeId)
+      this.rafStamps.invokeId = this.rafStamps.latestId;
+
+    if (!this.pendingCanvasMutations.has(target)) {
+      this.pendingCanvasMutations.set(target, []);
+    }
+
+    this.pendingCanvasMutations.get(target)!.push(mutation);
+  };
+
+  private initCanvasFPSObserver(
+    fps: number,
+    win: IWindow,
+    blockClass: blockClass,
+    blockSelector: string | null,
+    options: {
+      dataURLOptions: DataURLOptions;
+    },
+  ) {
+    const canvasContextReset = initCanvasContextObserver(
+      win,
+      blockClass,
+      blockSelector,
+      true,
+    );
+    const snapshotInProgressMap: Map<number, boolean> = new Map();
+    const worker = new ImageBitmapDataURLWorker() as ImageBitmapDataURLRequestWorker;
+
+    console.log('worker ====>', worker);
+
+    worker.onmessage = (e) => {
+      const { id } = e.data;
+      snapshotInProgressMap.set(id, false);
+
+      if (!('base64' in e.data)) return;
+
+      const { base64, type, width, height } = e.data;
+      this.mutationCb({
+        id,
+        type: CanvasContext['2D'],
+        commands: [
+          {
+            property: 'clearRect', // wipe canvas
+            args: [0, 0, width, height],
+          },
+          {
+            property: 'drawImage', // draws (semi-transparent) image
+            args: [
+              {
+                rr_type: 'ImageBitmap',
+                args: [
+                  {
+                    rr_type: 'Blob',
+                    data: [{ rr_type: 'ArrayBuffer', base64 }],
+                    type,
+                  },
+                ],
+              } as CanvasArg,
+              0,
+              0,
+            ],
+          },
+        ],
+      });
+    };
+
+    const timeBetweenSnapshots = 1000 / fps;
+    let lastSnapshotTime = 0;
+    let rafId: number;
+
+    const getCanvas = (): HTMLCanvasElement[] => {
+      const matchedCanvas: HTMLCanvasElement[] = [];
+      win.document.querySelectorAll('canvas').forEach((canvas) => {
+        if (!isBlocked(canvas, blockClass)) {
+          matchedCanvas.push(canvas);
+        }
+      });
+      return matchedCanvas;
+    };
+
+    const takeCanvasSnapshots = (timestamp: DOMHighResTimeStamp) => {
+      if (
+        lastSnapshotTime &&
+        timestamp - lastSnapshotTime < timeBetweenSnapshots
+      ) {
+        rafId = requestAnimationFrame(takeCanvasSnapshots);
+        return;
+      }
+      lastSnapshotTime = timestamp;
+
+      getCanvas()
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        .forEach(async (canvas: HTMLCanvasElement) => {
+          const id = this.mirror.getId((canvas as unknown) as INode);
+          if (snapshotInProgressMap.get(id)) return;
+
+          // The browser throws if the canvas is 0 in size
+          // Uncaught (in promise) DOMException: Failed to execute 'createImageBitmap' on 'Window': The source image width is 0.
+          // Assuming the same happens with height
+          if (canvas.width === 0 || canvas.height === 0) return;
+
+          snapshotInProgressMap.set(id, true);
+          if (['webgl', 'webgl2'].includes((canvas as ICanvas).__context)) {
+            // if the canvas hasn't been modified recently,
+            // its contents won't be in memory and `createImageBitmap`
+            // will return a transparent imageBitmap
+
+            const context = canvas.getContext((canvas as ICanvas).__context) as
+              | WebGLRenderingContext
+              | WebGL2RenderingContext
+              | null;
+            if (
+              context?.getContextAttributes()?.preserveDrawingBuffer === false
+            ) {
+              // Hack to load canvas back into memory so `createImageBitmap` can grab it's contents.
+              // Context: https://twitter.com/Juice10/status/1499775271758704643
+              // Preferably we set `preserveDrawingBuffer` to true, but that's not always possible,
+              // especially when canvas is loaded before rrweb.
+              // This hack can wipe the background color of the canvas in the (unlikely) event that
+              // the canvas background was changed but clear was not called directly afterwards.
+              // Example of this hack having negative side effect: https://visgl.github.io/react-map-gl/examples/layers
+              context.clear(context.COLOR_BUFFER_BIT);
+            }
+          }
+          const bitmap = await createImageBitmap(canvas);
+          worker.postMessage(
+            {
+              id,
+              bitmap,
+              width: canvas.width,
+              height: canvas.height,
+              dataURLOptions: options.dataURLOptions,
+            },
+            [bitmap],
+          );
+        });
+      rafId = requestAnimationFrame(takeCanvasSnapshots);
+    };
+
+    rafId = requestAnimationFrame(takeCanvasSnapshots);
+
+    this.resetObservers = () => {
+      canvasContextReset();
+      cancelAnimationFrame(rafId);
+    };
+  }
+
+  private initCanvasMutationObserver(
+    win: IWindow,
+    blockClass: blockClass,
+    blockSelector: string | null,
+  ): void {
+    this.startRAFTimestamping();
+    this.startPendingCanvasMutationFlusher();
+
+    const canvasContextReset = initCanvasContextObserver(
+      win,
+      blockClass,
+      blockSelector,
+      false,
+    );
+    const canvas2DReset = initCanvas2DMutationObserver(
+      this.processMutation.bind(this),
+      win,
+      blockClass,
+      blockSelector,
+    );
+
+    const canvasWebGL1and2Reset = initCanvasWebGLMutationObserver(
+      this.processMutation.bind(this),
+      win,
+      blockClass,
+      blockSelector,
+    );
+
+    this.resetObservers = () => {
+      canvasContextReset();
+      canvas2DReset();
+      canvasWebGL1and2Reset();
+    };
+  }
+
+  private startPendingCanvasMutationFlusher() {
+    requestAnimationFrame(() => this.flushPendingCanvasMutations());
+  }
+
+  private startRAFTimestamping() {
+    const setLatestRAFTimestamp = (timestamp: DOMHighResTimeStamp) => {
+      this.rafStamps.latestId = timestamp;
+      requestAnimationFrame(setLatestRAFTimestamp);
+    };
+    requestAnimationFrame(setLatestRAFTimestamp);
+  }
+
+  flushPendingCanvasMutations() {
+    this.pendingCanvasMutations.forEach(
+      (_values: canvasMutationCommand[], canvas: HTMLCanvasElement) => {
+        const id = this.mirror.getId((canvas as unknown) as INode);
+        this.flushPendingCanvasMutationFor(canvas, id);
+      },
+    );
+    requestAnimationFrame(() => this.flushPendingCanvasMutations());
+  }
+
+  flushPendingCanvasMutationFor(canvas: HTMLCanvasElement, id: number) {
+    if (this.frozen || this.locked) {
+      return;
+    }
+
+    const valuesWithType = this.pendingCanvasMutations.get(canvas);
+    if (!valuesWithType || id === -1) return;
+
+    const values = valuesWithType.map((value) => {
+      const { type, ...rest } = value;
+      return rest;
+    });
+    const { type } = valuesWithType[0];
+
+    this.mutationCb({ id, type, commands: values });
+
+    this.pendingCanvasMutations.delete(canvas);
+  }
+}

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -74,7 +74,6 @@ export class CanvasManager {
       recordCanvas,
       dataURLOptions,
     } = options;
-    console.log('recordCanvas ====>', recordCanvas);
     this.mutationCb = options.mutationCb;
     this.mirror = options.mirror;
 
@@ -121,8 +120,6 @@ export class CanvasManager {
     );
     const snapshotInProgressMap: Map<number, boolean> = new Map();
     const worker = new ImageBitmapDataURLWorker() as ImageBitmapDataURLRequestWorker;
-
-    console.log('worker ====>', worker);
 
     worker.onmessage = (e) => {
       const { id } = e.data;

--- a/packages/rrweb/src/record/observers/canvas/canvas.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas.ts
@@ -1,0 +1,63 @@
+import type { ICanvas } from 'rrweb-snapshot';
+import type { blockClass, IWindow, listenerHandler } from '../../../types';
+import { isBlocked, patch } from '../../../utils';
+
+function getNormalizedContextName(contextType: string) {
+  return contextType === 'experimental-webgl' ? 'webgl' : contextType;
+}
+
+export default function initCanvasContextObserver(
+  win: IWindow,
+  blockClass: blockClass,
+  blockSelector: string | null,
+  setPreserveDrawingBufferToTrue: boolean,
+): listenerHandler {
+  const handlers: listenerHandler[] = [];
+  try {
+    const restoreHandler = patch(
+      win.HTMLCanvasElement.prototype,
+      'getContext',
+      function (
+        original: (
+          this: ICanvas | HTMLCanvasElement,
+          contextType: string,
+          ...args: Array<unknown>
+        ) => void,
+      ) {
+        return function (
+          this: ICanvas | HTMLCanvasElement,
+          contextType: string,
+          ...args: Array<unknown>
+        ) {
+          if (!isBlocked(this, blockClass)) {
+            const ctxName = getNormalizedContextName(contextType);
+            if (!('__context' in this)) (this as ICanvas).__context = ctxName;
+
+            if (
+              setPreserveDrawingBufferToTrue &&
+              ['webgl', 'webgl2'].includes(ctxName)
+            ) {
+              if (args[0] && typeof args[0] === 'object') {
+                const contextAttributes = args[0] as WebGLContextAttributes;
+                if (!contextAttributes.preserveDrawingBuffer) {
+                  contextAttributes.preserveDrawingBuffer = true;
+                }
+              } else {
+                args.splice(0, 1, {
+                  preserveDrawingBuffer: true,
+                });
+              }
+            }
+          }
+          return original.apply(this, [contextType, ...args]);
+        };
+      },
+    );
+    handlers.push(restoreHandler);
+  } catch {
+    console.error('failed to patch HTMLCanvasElement.prototype.getContext');
+  }
+  return () => {
+    handlers.forEach((h) => h());
+  };
+}

--- a/packages/rrweb/src/record/observers/canvas/serialize-args.ts
+++ b/packages/rrweb/src/record/observers/canvas/serialize-args.ts
@@ -1,0 +1,168 @@
+import { encode } from 'base64-arraybuffer';
+import type { IWindow, CanvasArg } from '../../../types';
+
+// TODO: unify with `replay/webgl.ts`
+type CanvasVarMap = Map<string, unknown[]>;
+const canvasVarMap: Map<RenderingContext, CanvasVarMap> = new Map();
+export function variableListFor(ctx: RenderingContext, ctor: string) {
+  let contextMap = canvasVarMap.get(ctx);
+  if (!contextMap) {
+    contextMap = new Map();
+    canvasVarMap.set(ctx, contextMap);
+  }
+  if (!contextMap.has(ctor)) {
+    contextMap.set(ctor, []);
+  }
+  return contextMap.get(ctor) as unknown[];
+}
+
+export const saveWebGLVar = (
+  value: unknown,
+  win: IWindow,
+  ctx: RenderingContext,
+): number | void => {
+  if (
+    !value ||
+    !(isInstanceOfWebGLObject(value, win) || typeof value === 'object')
+  )
+    return;
+
+  const name = value?.constructor.name || '';
+  const list = variableListFor(ctx, name);
+  let index = list.indexOf(value);
+
+  if (index === -1) {
+    index = list.length;
+    list.push(value);
+  }
+  return index;
+};
+
+// from webgl-recorder: https://github.com/evanw/webgl-recorder/blob/bef0e65596e981ee382126587e2dcbe0fc7748e2/webgl-recorder.js#L50-L77
+export function serializeArg(
+  value: unknown,
+  win: IWindow,
+  ctx: RenderingContext,
+): CanvasArg {
+  if (value instanceof Array) {
+    return value.map((arg) => serializeArg(arg, win, ctx));
+  } else if (value === null) {
+    return value;
+  } else if (
+    value instanceof Float32Array ||
+    value instanceof Float64Array ||
+    value instanceof Int32Array ||
+    value instanceof Uint32Array ||
+    value instanceof Uint8Array ||
+    value instanceof Uint16Array ||
+    value instanceof Int16Array ||
+    value instanceof Int8Array ||
+    value instanceof Uint8ClampedArray
+  ) {
+    const name = value.constructor.name;
+    return {
+      rr_type: name,
+      args: [Object.values(value)],
+    };
+  } else if (
+    // SharedArrayBuffer disabled on most browsers due to spectre.
+    // More info: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer
+    // value instanceof SharedArrayBuffer ||
+    value instanceof ArrayBuffer
+  ) {
+    const name = value.constructor.name as 'ArrayBuffer';
+    const base64 = encode(value);
+
+    return {
+      rr_type: name,
+      base64,
+    };
+  } else if (value instanceof DataView) {
+    const name = value.constructor.name;
+    return {
+      rr_type: name,
+      args: [
+        serializeArg(value.buffer, win, ctx),
+        value.byteOffset,
+        value.byteLength,
+      ],
+    };
+  } else if (value instanceof HTMLImageElement) {
+    const name = value.constructor.name;
+    const { src } = value;
+    return {
+      rr_type: name,
+      src,
+    };
+  } else if (value instanceof HTMLCanvasElement) {
+    const name = 'HTMLImageElement';
+    // TODO: move `toDataURL` to web worker if possible
+    const src = value.toDataURL(); // heavy on large canvas
+    return {
+      rr_type: name,
+      src,
+    };
+  } else if (value instanceof ImageData) {
+    const name = value.constructor.name;
+    return {
+      rr_type: name,
+      args: [serializeArg(value.data, win, ctx), value.width, value.height],
+    };
+  } else if (isInstanceOfWebGLObject(value, win) || typeof value === 'object') {
+    const name = value?.constructor.name || '';
+    const index = saveWebGLVar(value, win, ctx) as number;
+
+    return {
+      rr_type: name,
+      index,
+    };
+  }
+
+  return value as unknown as CanvasArg;
+}
+
+export const serializeArgs = (
+  args: Array<unknown>,
+  win: IWindow,
+  ctx: RenderingContext,
+) => {
+  return args.map((arg) => serializeArg(arg, win, ctx));
+};
+
+export const isInstanceOfWebGLObject = (
+  value: unknown,
+  win: IWindow,
+): value is
+  | WebGLActiveInfo
+  | WebGLBuffer
+  | WebGLFramebuffer
+  | WebGLProgram
+  | WebGLRenderbuffer
+  | WebGLShader
+  | WebGLShaderPrecisionFormat
+  | WebGLTexture
+  | WebGLUniformLocation
+  | WebGLVertexArrayObject => {
+  const webGLConstructorNames: string[] = [
+    'WebGLActiveInfo',
+    'WebGLBuffer',
+    'WebGLFramebuffer',
+    'WebGLProgram',
+    'WebGLRenderbuffer',
+    'WebGLShader',
+    'WebGLShaderPrecisionFormat',
+    'WebGLTexture',
+    'WebGLUniformLocation',
+    'WebGLVertexArrayObject',
+    // In old Chrome versions, value won't be an instanceof WebGLVertexArrayObject.
+    'WebGLVertexArrayObjectOES',
+  ];
+  const supportedWebGLConstructorNames = webGLConstructorNames.filter(
+    (name: string) => typeof win[name as keyof Window] === 'function',
+  );
+  return Boolean(
+    supportedWebGLConstructorNames.find(
+      (name: string) => value instanceof win[name as keyof Window],
+    ),
+  );
+};

--- a/packages/rrweb/src/record/observers/canvas/webgl.ts
+++ b/packages/rrweb/src/record/observers/canvas/webgl.ts
@@ -1,0 +1,124 @@
+import {
+  blockClass,
+  CanvasContext,
+  canvasManagerMutationCallback,
+  canvasMutationWithType,
+  IWindow,
+  listenerHandler,
+} from '../../../types';
+import { hookSetter, isBlocked, patch } from '../../../utils';
+import { saveWebGLVar, serializeArgs } from './serialize-args';
+
+function patchGLPrototype(
+  prototype: WebGLRenderingContext | WebGL2RenderingContext,
+  type: CanvasContext,
+  cb: canvasManagerMutationCallback,
+  blockClass: blockClass,
+  blockSelector: string | null,
+  win: IWindow,
+): listenerHandler[] {
+  const handlers: listenerHandler[] = [];
+
+  const props = Object.getOwnPropertyNames(prototype);
+
+  for (const prop of props) {
+    if (
+      // prop.startsWith('get') ||  // e.g. getProgramParameter, but too risky
+      [
+        'isContextLost',
+        'canvas',
+        'drawingBufferWidth',
+        'drawingBufferHeight',
+      ].includes(prop)
+    ) {
+      // skip read only propery/functions
+      continue;
+    }
+    try {
+      if (typeof prototype[prop as keyof typeof prototype] !== 'function') {
+        continue;
+      }
+      const restoreHandler = patch(
+        prototype,
+        prop,
+        function (
+          original: (this: typeof prototype, ...args: Array<unknown>) => void,
+        ) {
+          return function (this: typeof prototype, ...args: Array<unknown>) {
+            const result = original.apply(this, args);
+            saveWebGLVar(result, win, this);
+            if (
+              'tagName' in this.canvas &&
+              !isBlocked(this.canvas, blockClass)
+            ) {
+              const recordArgs = serializeArgs(args, win, this);
+              const mutation: canvasMutationWithType = {
+                type,
+                property: prop,
+                args: recordArgs,
+              };
+              // TODO: this could potentially also be an OffscreenCanvas as well as HTMLCanvasElement
+              cb(this.canvas, mutation);
+            }
+
+            return result;
+          };
+        },
+      );
+      handlers.push(restoreHandler);
+    } catch {
+      const hookHandler = hookSetter<typeof prototype>(prototype, prop, {
+        set(v) {
+          // TODO: this could potentially also be an OffscreenCanvas as well as HTMLCanvasElement
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          cb(this.canvas as HTMLCanvasElement, {
+            type,
+            property: prop,
+            args: [v],
+            setter: true,
+          });
+        },
+      });
+      handlers.push(hookHandler);
+    }
+  }
+
+  return handlers;
+}
+
+export default function initCanvasWebGLMutationObserver(
+  cb: canvasManagerMutationCallback,
+  win: IWindow,
+  blockClass: blockClass,
+  blockSelector: string | null,
+): listenerHandler {
+  const handlers: listenerHandler[] = [];
+
+  handlers.push(
+    ...patchGLPrototype(
+      win.WebGLRenderingContext.prototype,
+      CanvasContext.WebGL,
+      cb,
+      blockClass,
+      blockSelector,
+      win,
+    ),
+  );
+
+  if (typeof win.WebGL2RenderingContext !== 'undefined') {
+    handlers.push(
+      ...patchGLPrototype(
+        win.WebGL2RenderingContext.prototype,
+        CanvasContext.WebGL2,
+        cb,
+        blockClass,
+        blockSelector,
+        win,
+      ),
+    );
+  }
+
+  return () => {
+    handlers.forEach((h) => h());
+  };
+}

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -12,9 +12,11 @@ import {
   MaskTextFn,
   MaskInputFn,
   MaskImageFn,
+  DataURLOptions,
 } from 'rrweb-snapshot';
 import { IframeManager } from './iframe-manager';
 import { initMutationObserver, initScrollObserver } from './observer';
+import { CanvasManager } from './observers/canvas/canvas-manager';
 
 type BypassOptions = {
   blockClass: blockClass;
@@ -27,11 +29,13 @@ type BypassOptions = {
   maskTextFn: MaskTextFn | undefined;
   maskInputFn: MaskInputFn | undefined;
   maskImageFn?: MaskImageFn;
+  dataURLOptions: DataURLOptions;
   recordCanvas: boolean;
   inlineImages: boolean;
   sampling: SamplingStrategy;
   slimDOMOptions: SlimDOMOptions;
   iframeManager: IframeManager;
+  canvasManager: CanvasManager;
 };
 
 export class ShadowDomManager {
@@ -69,9 +73,11 @@ export class ShadowDomManager {
       this.bypassOptions.recordCanvas,
       this.bypassOptions.inlineImages,
       this.bypassOptions.slimDOMOptions,
+      this.bypassOptions.dataURLOptions,
       this.mirror,
       this.bypassOptions.iframeManager,
       this,
+      this.bypassOptions.canvasManager,
       shadowRoot,
     );
     initScrollObserver(

--- a/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
@@ -29,7 +29,6 @@ async function getTransparentBlobFor(
   dataURLOptions: DataURLOptions,
 ): Promise<string> {
   const id = `${width}-${height}`;
-  console.log('got iddddd', id);
   if ('OffscreenCanvas' in globalThis) {
     if (transparentBlobMap.has(id)) return transparentBlobMap.get(id)!;
     const offscreen = new OffscreenCanvas(width, height);
@@ -50,10 +49,8 @@ const worker = (self as unknown) as ImageBitmapDataURLResponseWorker;
 
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 worker.onmessage = async function (e) {
-  console.log('globalThis', globalThis);
   if ('OffscreenCanvas' in globalThis) {
     const { id, bitmap, width, height, dataURLOptions } = e.data;
-    console.log('got here', e.data);
 
     const transparentBase64 = getTransparentBlobFor(
       width,

--- a/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb/src/record/workers/image-bitmap-data-url-worker.ts
@@ -1,0 +1,93 @@
+import { encode } from 'base64-arraybuffer';
+import type { DataURLOptions } from 'rrweb-snapshot';
+import type {
+  ImageBitmapDataURLWorkerParams,
+  ImageBitmapDataURLWorkerResponse,
+} from '../../types';
+
+const lastBlobMap: Map<number, string> = new Map();
+const transparentBlobMap: Map<string, string> = new Map();
+
+export interface ImageBitmapDataURLRequestWorker {
+  postMessage: (
+    message: ImageBitmapDataURLWorkerParams,
+    transfer?: [ImageBitmap],
+  ) => void;
+  onmessage: (message: MessageEvent<ImageBitmapDataURLWorkerResponse>) => void;
+}
+
+interface ImageBitmapDataURLResponseWorker {
+  onmessage:
+    | null
+    | ((message: MessageEvent<ImageBitmapDataURLWorkerParams>) => void);
+  postMessage(e: ImageBitmapDataURLWorkerResponse): void;
+}
+
+async function getTransparentBlobFor(
+  width: number,
+  height: number,
+  dataURLOptions: DataURLOptions,
+): Promise<string> {
+  const id = `${width}-${height}`;
+  console.log('got iddddd', id);
+  if ('OffscreenCanvas' in globalThis) {
+    if (transparentBlobMap.has(id)) return transparentBlobMap.get(id)!;
+    const offscreen = new OffscreenCanvas(width, height);
+    offscreen.getContext('2d'); // creates rendering context for `convertToBlob`
+    const blob = await offscreen.convertToBlob(dataURLOptions); // takes a while
+    const arrayBuffer = await blob.arrayBuffer();
+    const base64 = encode(arrayBuffer); // cpu intensive
+    transparentBlobMap.set(id, base64);
+    return base64;
+  } else {
+    return '';
+  }
+}
+
+const worker = (self as unknown) as ImageBitmapDataURLResponseWorker;
+
+// `as any` because: https://github.com/Microsoft/TypeScript/issues/20595
+
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+worker.onmessage = async function (e) {
+  console.log('globalThis', globalThis);
+  if ('OffscreenCanvas' in globalThis) {
+    const { id, bitmap, width, height, dataURLOptions } = e.data;
+    console.log('got here', e.data);
+
+    const transparentBase64 = getTransparentBlobFor(
+      width,
+      height,
+      dataURLOptions,
+    );
+
+    const offscreen = new OffscreenCanvas(width, height);
+    const ctx = offscreen.getContext('2d')!;
+
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close();
+    const blob = await offscreen.convertToBlob(dataURLOptions); // takes a while
+    const type = blob.type;
+    const arrayBuffer = await blob.arrayBuffer();
+    const base64 = encode(arrayBuffer); // cpu intensive
+
+    // on first try we should check if canvas is transparent,
+    // no need to save it's contents in that case
+    if (!lastBlobMap.has(id) && (await transparentBase64) === base64) {
+      lastBlobMap.set(id, base64);
+      return worker.postMessage({ id });
+    }
+
+    if (lastBlobMap.get(id) === base64) return worker.postMessage({ id }); // unchanged
+    worker.postMessage({
+      id,
+      type,
+      base64,
+      width,
+      height,
+    });
+    lastBlobMap.set(id, base64);
+  } else {
+    return worker.postMessage({ id: e.data.id });
+  }
+};

--- a/packages/rrweb/src/record/workers/tsconfig.json
+++ b/packages/rrweb/src/record/workers/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["webworker"]
+  },
+  "exclude": ["workers.d.ts"]
+}

--- a/packages/rrweb/src/record/workers/worker.d.ts
+++ b/packages/rrweb/src/record/workers/worker.d.ts
@@ -1,0 +1,4 @@
+declare module 'web-worker:*' {
+  const WorkerFactory: new () => Worker;
+  export default WorkerFactory;
+}

--- a/packages/rrweb/src/replay/canvas/2d.ts
+++ b/packages/rrweb/src/replay/canvas/2d.ts
@@ -1,0 +1,66 @@
+import type { Replayer } from '../';
+import type { canvasMutationCommand } from '../../types';
+import { deserializeArg } from './deserialize-args';
+
+export default async function canvasMutation({
+  event,
+  mutations,
+  target,
+  imageMap,
+  errorHandler,
+}: {
+  event: Parameters<Replayer['applyIncremental']>[0];
+  mutations: canvasMutationCommand[];
+  target: HTMLCanvasElement;
+  imageMap: Replayer['imageMap'];
+  errorHandler: Replayer['warnCanvasMutationFailed'];
+}): Promise<void> {
+  const ctx = target.getContext('2d');
+
+  if (!ctx) {
+    errorHandler(mutations[0], new Error('Canvas context is null'));
+    return;
+  }
+
+  // step 1, deserialize args, they may be async
+  const mutationArgsPromises = mutations.map(
+    async (mutation: canvasMutationCommand): Promise<unknown[]> => {
+      return Promise.all(mutation.args.map(deserializeArg(imageMap, ctx)));
+    },
+  );
+  const args = await Promise.all(mutationArgsPromises);
+  // step 2 apply all mutations
+  args.forEach((args, index) => {
+    const mutation = mutations[index];
+    try {
+      if (mutation.setter) {
+        // skip some read-only type checks
+        (ctx as unknown as Record<string, unknown>)[mutation.property] =
+          mutation.args[0];
+        return;
+      }
+      const original = ctx[
+        mutation.property as Exclude<keyof typeof ctx, 'canvas'>
+      ] as (ctx: CanvasRenderingContext2D, args: unknown[]) => void;
+
+      /**
+       * We have serialized the image source into base64 string during recording,
+       * which has been preloaded before replay.
+       * So we can get call drawImage SYNCHRONOUSLY which avoid some fragile cast.
+       */
+      if (
+        mutation.property === 'drawImage' &&
+        typeof mutation.args[0] === 'string'
+      ) {
+        imageMap.get(event);
+        original.apply(ctx, mutation.args);
+      } else {
+        original.apply(ctx, args);
+      }
+    } catch (error) {
+      errorHandler(mutation, error);
+    }
+
+    return;
+  });
+}

--- a/packages/rrweb/src/replay/canvas/deserialize-args.ts
+++ b/packages/rrweb/src/replay/canvas/deserialize-args.ts
@@ -1,0 +1,99 @@
+import { decode } from 'base64-arraybuffer';
+import type { Replayer } from '../';
+import type { CanvasArg, SerializedCanvasArg } from '../../types';
+
+// TODO: add ability to wipe this list
+type GLVarMap = Map<string, any[]>;
+const webGLVarMap: Map<
+  CanvasRenderingContext2D | WebGLRenderingContext | WebGL2RenderingContext,
+  GLVarMap
+> = new Map();
+export function variableListFor(
+  ctx:
+    | CanvasRenderingContext2D
+    | WebGLRenderingContext
+    | WebGL2RenderingContext,
+  ctor: string,
+) {
+  let contextMap = webGLVarMap.get(ctx);
+  if (!contextMap) {
+    contextMap = new Map();
+    webGLVarMap.set(ctx, contextMap);
+  }
+  if (!contextMap.has(ctor)) {
+    contextMap.set(ctor, []);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return contextMap.get(ctor) as any[];
+}
+
+export function isSerializedArg(arg: unknown): arg is SerializedCanvasArg {
+  return Boolean(arg && typeof arg === 'object' && 'rr_type' in arg);
+}
+
+export function deserializeArg(
+  imageMap: Replayer['imageMap'],
+  ctx:
+    | CanvasRenderingContext2D
+    | WebGLRenderingContext
+    | WebGL2RenderingContext
+    | null,
+  preload?: {
+    isUnchanged: boolean;
+  },
+): (arg: CanvasArg) => Promise<any> {
+  return async (arg: CanvasArg): Promise<any> => {
+    if (arg && typeof arg === 'object' && 'rr_type' in arg) {
+      if (preload) preload.isUnchanged = false;
+      if (arg.rr_type === 'ImageBitmap' && 'args' in arg) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const args = await deserializeArg(imageMap, ctx, preload)(arg.args);
+        // eslint-disable-next-line prefer-spread
+        return await createImageBitmap.apply(null, args);
+      } else if ('index' in arg) {
+        if (preload || ctx === null) return arg; // we are preloading, ctx is unknown
+        const { rr_type: name, index } = arg;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return variableListFor(ctx, name)[index];
+      } else if ('args' in arg) {
+        const { rr_type: name, args } = arg;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const ctor = window[name as keyof Window];
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+        return new ctor(
+          ...(await Promise.all(
+            args.map(deserializeArg(imageMap, ctx, preload)),
+          )),
+        );
+      } else if ('base64' in arg) {
+        return decode(arg.base64);
+      } else if ('src' in arg) {
+        const image = imageMap.get(arg.src);
+        if (image) {
+          return image;
+        } else {
+          const image = new Image();
+          image.src = arg.src;
+          imageMap.set(arg.src, image);
+          return image;
+        }
+      } else if ('data' in arg && arg.rr_type === 'Blob') {
+        const blobContents = await Promise.all(
+          arg.data.map(deserializeArg(imageMap, ctx, preload)),
+        );
+        const blob = new Blob(blobContents, {
+          type: arg.type,
+        });
+        return blob;
+      }
+    } else if (Array.isArray(arg)) {
+      const result = await Promise.all(
+        arg.map(deserializeArg(imageMap, ctx, preload)),
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return result;
+    }
+    return arg;
+  };
+}

--- a/packages/rrweb/src/replay/canvas/index.ts
+++ b/packages/rrweb/src/replay/canvas/index.ts
@@ -1,0 +1,59 @@
+import type { Replayer } from '..';
+import {
+  CanvasContext,
+  canvasMutationCommand,
+  canvasMutationData,
+  canvasMutationParam,
+} from '../../types';
+import webglMutation from './webgl';
+import canvas2DMutation from './2d';
+
+export default async function canvasMutation({
+  event,
+  mutation,
+  target,
+  imageMap,
+  canvasEventMap,
+  errorHandler,
+}: {
+  event: Parameters<Replayer['applyIncremental']>[0];
+  mutation: canvasMutationData;
+  target: HTMLCanvasElement;
+  imageMap: Replayer['imageMap'];
+  canvasEventMap: Replayer['canvasEventMap'];
+  errorHandler: Replayer['warnCanvasMutationFailed'];
+}): Promise<void> {
+  try {
+    const precomputedMutation: canvasMutationParam =
+      canvasEventMap.get(event) || mutation;
+
+    const commands: canvasMutationCommand[] =
+      'commands' in precomputedMutation
+        ? precomputedMutation.commands
+        : [precomputedMutation];
+
+    if ([CanvasContext.WebGL, CanvasContext.WebGL2].includes(mutation.type)) {
+      for (let i = 0; i < commands.length; i++) {
+        const command = commands[i];
+        await webglMutation({
+          mutation: command,
+          type: mutation.type,
+          target,
+          imageMap,
+          errorHandler,
+        });
+      }
+      return;
+    }
+    // default is '2d' for backwards compatibility (rrweb below 1.1.x)
+    await canvas2DMutation({
+      event,
+      mutations: commands,
+      target,
+      imageMap,
+      errorHandler,
+    });
+  } catch (error) {
+    errorHandler(mutation, error);
+  }
+}

--- a/packages/rrweb/src/replay/canvas/webgl.ts
+++ b/packages/rrweb/src/replay/canvas/webgl.ts
@@ -1,0 +1,131 @@
+import type { Replayer } from '../';
+import { CanvasContext, canvasMutationCommand } from '../../types';
+import { deserializeArg, variableListFor } from './deserialize-args';
+
+function getContext(
+  target: HTMLCanvasElement,
+  type: CanvasContext,
+): WebGLRenderingContext | WebGL2RenderingContext | null {
+  // Note to whomever is going to implement support for `contextAttributes`:
+  // if `preserveDrawingBuffer` is set to true,
+  // you might have to do `ctx.flush()` before every webgl canvas event
+  try {
+    if (type === CanvasContext.WebGL) {
+      return (
+        target.getContext('webgl')! || target.getContext('experimental-webgl')
+      );
+    }
+    return target.getContext('webgl2')!;
+  } catch (e) {
+    return null;
+  }
+}
+
+const WebGLVariableConstructorsNames = [
+  'WebGLActiveInfo',
+  'WebGLBuffer',
+  'WebGLFramebuffer',
+  'WebGLProgram',
+  'WebGLRenderbuffer',
+  'WebGLShader',
+  'WebGLShaderPrecisionFormat',
+  'WebGLTexture',
+  'WebGLUniformLocation',
+  'WebGLVertexArrayObject',
+];
+
+function saveToWebGLVarMap(
+  ctx: WebGLRenderingContext | WebGL2RenderingContext,
+  result: any,
+) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (!result?.constructor) return; // probably null or undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+  const { name } = result.constructor;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  if (!WebGLVariableConstructorsNames.includes(name)) return; // not a WebGL variable
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const variables = variableListFor(ctx, name);
+  if (!variables.includes(result)) variables.push(result);
+}
+
+export default async function webglMutation({
+  mutation,
+  target,
+  type,
+  imageMap,
+  errorHandler,
+}: {
+  mutation: canvasMutationCommand;
+  target: HTMLCanvasElement;
+  type: CanvasContext;
+  imageMap: Replayer['imageMap'];
+  errorHandler: Replayer['warnCanvasMutationFailed'];
+}): Promise<void> {
+  try {
+    const ctx = getContext(target, type);
+    if (!ctx) return;
+
+    // NOTE: if `preserveDrawingBuffer` is set to true,
+    // we must flush the buffers on every new canvas event
+    // if (mutation.newFrame) ctx.flush();
+
+    if (mutation.setter) {
+      // skip some read-only type checks
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (ctx as any)[mutation.property] = mutation.args[0];
+      return;
+    }
+    const original = ctx[
+      mutation.property as Exclude<keyof typeof ctx, 'canvas'>
+    ] as (
+      ctx: WebGLRenderingContext | WebGL2RenderingContext,
+      args: unknown[],
+    ) => void;
+
+    const args = await Promise.all(
+      mutation.args.map(deserializeArg(imageMap, ctx)),
+    );
+    const result = original.apply(ctx, args);
+    saveToWebGLVarMap(ctx, result);
+
+    // Slows down replay considerably, only use for debugging
+    const debugMode = false;
+    if (debugMode) {
+      if (mutation.property === 'compileShader') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (!ctx.getShaderParameter(args[0], ctx.COMPILE_STATUS))
+          console.warn(
+            'something went wrong in replay',
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            ctx.getShaderInfoLog(args[0]),
+          );
+      } else if (mutation.property === 'linkProgram') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        ctx.validateProgram(args[0]);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        if (!ctx.getProgramParameter(args[0], ctx.LINK_STATUS))
+          console.warn(
+            'something went wrong in replay',
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            ctx.getProgramInfoLog(args[0]),
+          );
+      }
+      const webglError = ctx.getError();
+      if (webglError !== ctx.NO_ERROR) {
+        console.warn(
+          'WEBGL ERROR',
+          webglError,
+          'on command:',
+          mutation.property,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ...args,
+        );
+      }
+    }
+  } catch (error) {
+    errorHandler(mutation, error);
+  }
+}

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -153,7 +153,6 @@ export class Replayer {
     events: Array<eventWithTime | string>,
     config?: Partial<playerConfig>,
   ) {
-    console.log('Hello there, 19.11.24!');
     if (!config?.liveMode && events.length < 2) {
       throw new Error('Replayer need at least 2 events.');
     }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -77,7 +77,7 @@ import { applyDialogToTopLevel, removeDialogFromTopLevel } from './dialog';
 // This is a PostHog way to fix it: https://github.com/PostHog/posthog/pull/22942
 const shopifyShorthandCSSFix =
   '@media (prefers-reduced-motion: no-preference) { .scroll-trigger:not(.scroll-trigger--offscreen).animate--slide-in { animation: var(--animation-slide-in) } }';
-
+const canvasDisplayFallback = ':where(canvas) { display: inline-block; }';
 const hideCanvasChildrenExceptSnapshot =
   'canvas *:not(.rrweb-snapshot-canvas) { display: none; }';
 
@@ -168,6 +168,7 @@ export class Replayer {
       liveMode: false,
       insertStyleRules: [
         shopifyShorthandCSSFix,
+        canvasDisplayFallback,
         hideCanvasChildrenExceptSnapshot,
       ],
       triggerFocus: true,

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -160,7 +160,6 @@ export class Replayer {
     events: Array<eventWithTime | string>,
     config?: Partial<playerConfig>,
   ) {
-    console.log('HEY IN REPLAYER! 05.12');
     if (!config?.liveMode && events.length < 2) {
       throw new Error('Replayer need at least 2 events.');
     }

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -629,6 +629,10 @@ export type ReplayPlugin = {
     isSync: boolean,
     context: { replayer: Replayer },
   ) => void;
+  onBuild?: (node: Node, context: {
+    id: number;
+    replayer: Replayer;
+  }) => void;
 };
 export type playerConfig = {
   speed: number;

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -332,6 +332,7 @@ export class TreeIndex {
   private scrollMap!: Map<number, scrollData>;
   private inputMap!: Map<number, inputData>;
   private dialogMap!: Map<number, attributeMutation>;
+  private canvasAttributesMap!: Map<number, attributeMutation['attributes']>;
 
   constructor() {
     this.reset();
@@ -427,11 +428,21 @@ export class TreeIndex {
     this.dialogMap.set(d.id, d);
   }
 
+  public canvasAttribute(d: attributeMutation) {
+    const existingAttribute = this.canvasAttributesMap.get(d.id);
+    if (existingAttribute) {
+      this.canvasAttributesMap.set(d.id, Object.assign(existingAttribute, d.attributes));
+    } else {
+      this.canvasAttributesMap.set(d.id, d.attributes);
+    }
+  }
+
   public flush(): {
     mutationData: mutationData;
     scrollMap: TreeIndex['scrollMap'];
     inputMap: TreeIndex['inputMap'];
     dialogMap: TreeIndex['dialogMap'];
+    canvasAttributesMap: TreeIndex['canvasAttributesMap'];
   } {
     const {
       tree,
@@ -488,6 +499,7 @@ export class TreeIndex {
     const scrollMap = new Map(this.scrollMap);
     const inputMap = new Map(this.inputMap);
     const dialogMap = new Map(this.dialogMap);
+    const canvasAttributesMap = new Map(this.canvasAttributesMap);
 
     this.reset();
 
@@ -496,6 +508,7 @@ export class TreeIndex {
       scrollMap,
       inputMap,
       dialogMap,
+      canvasAttributesMap,
     };
   }
 
@@ -509,6 +522,7 @@ export class TreeIndex {
     this.scrollMap = new Map();
     this.inputMap = new Map();
     this.dialogMap = new Map();
+    this.canvasAttributesMap = new Map();
   }
 
   public idRemoved(id: number): boolean {
@@ -681,7 +695,10 @@ export function asyncLoop<T>(
     typeof nextCallbackId === 'number' && cancelFn(nextCallbackId);
   const processNextEvent = () => {
     const start = performance.now();
-    while (index < all.length && performance.now() - start < asyncLoopMaxFreezeTime) {
+    while (
+      index < all.length &&
+      performance.now() - start < asyncLoopMaxFreezeTime
+    ) {
       fn(all[index], index);
       index++;
     }

--- a/packages/rrweb/src/web.d.ts
+++ b/packages/rrweb/src/web.d.ts
@@ -20,3 +20,7 @@ declare var requestIdleCallback: (
   options?: { timeout: number },
 ) => number;
 declare var cancelIdleCallback: (handle: number) => void;
+
+interface MessageEvent<T = {}> extends Event {
+  readonly data: T | any;
+}

--- a/packages/rrweb/typings/index.d.ts
+++ b/packages/rrweb/typings/index.d.ts
@@ -1,9 +1,11 @@
 import record from './record';
 import { Replayer } from './replay';
+import canvasMutation from './replay/canvas';
 import { _mirror } from './utils';
 import * as utils from './utils';
 import * as replayUtils from './replay/utils';
+import { CanvasReplayerPlugin } from './plugins/replay-canvas-plugin/plugin';
 export { EventType, IncrementalSource, MouseInteractions, ReplayerEvents, } from './types';
 declare const addCustomEvent: <T>(tag: string, payload: T) => void;
 declare const freezePage: () => void;
-export { record, addCustomEvent, freezePage, Replayer, _mirror as mirror, utils, replayUtils, };
+export { record, addCustomEvent, freezePage, Replayer, _mirror as mirror, utils, replayUtils, canvasMutation, CanvasReplayerPlugin, };

--- a/packages/rrweb/typings/plugins/replay-canvas-plugin/debounce.d.ts
+++ b/packages/rrweb/typings/plugins/replay-canvas-plugin/debounce.d.ts
@@ -1,0 +1,1 @@
+export default function debounce<T extends (...args: Array<unknown>) => void>(func: T, wait: number, immediate?: boolean): (this: ThisParameterType<T>, ...args: Parameters<T>) => void;

--- a/packages/rrweb/typings/plugins/replay-canvas-plugin/deserialize-canvas-args.d.ts
+++ b/packages/rrweb/typings/plugins/replay-canvas-plugin/deserialize-canvas-args.d.ts
@@ -1,0 +1,7 @@
+import { Replayer } from '../../replay';
+import { CanvasArg } from '../../types';
+declare type CanvasContexts = CanvasRenderingContext2D | WebGLRenderingContext | WebGL2RenderingContext;
+export declare const deserializeCanvasArg: (imageMap: Replayer['imageMap'], ctx: CanvasContexts | null, preload?: {
+    isUnchanged: boolean;
+} | undefined) => (arg: CanvasArg) => Promise<any>;
+export {};

--- a/packages/rrweb/typings/plugins/replay-canvas-plugin/plugin.d.ts
+++ b/packages/rrweb/typings/plugins/replay-canvas-plugin/plugin.d.ts
@@ -1,0 +1,3 @@
+import type { ReplayPlugin } from '../../types';
+import { Replayer } from '../../replay';
+export declare function CanvasReplayerPlugin(rrwebReplayer: Replayer | null): ReplayPlugin;

--- a/packages/rrweb/typings/record/mutation.d.ts
+++ b/packages/rrweb/typings/record/mutation.d.ts
@@ -1,6 +1,7 @@
-import { MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn, MaskImageFn } from 'rrweb-snapshot';
+import { MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn, MaskImageFn, DataURLOptions } from 'rrweb-snapshot';
 import { mutationRecord, blockClass, maskTextClass, mutationCallBack, Mirror } from '../types';
 import { IframeManager } from './iframe-manager';
+import { CanvasManager } from './observers/canvas/canvas-manager';
 import { ShadowDomManager } from './shadow-dom-manager';
 export default class MutationBuffer {
     private frozen;
@@ -27,16 +28,19 @@ export default class MutationBuffer {
     private recordCanvas;
     private inlineImages;
     private slimDOMOptions;
+    private dataURLOptions;
     private doc;
     private mirror;
     private iframeManager;
     private shadowDomManager;
-    init(cb: mutationCallBack, blockClass: blockClass, blockSelector: string | null, maskTextClass: maskTextClass, maskTextSelector: string | null, maskAll: boolean | undefined, inlineStylesheet: boolean, maskInputOptions: MaskInputOptions, maskTextFn: MaskTextFn | undefined, maskInputFn: MaskInputFn | undefined, maskImageFn: MaskImageFn | undefined, recordCanvas: boolean, inlineImages: boolean, slimDOMOptions: SlimDOMOptions, doc: Document, mirror: Mirror, iframeManager: IframeManager, shadowDomManager: ShadowDomManager): void;
+    private canvasManager;
+    init(cb: mutationCallBack, blockClass: blockClass, blockSelector: string | null, maskTextClass: maskTextClass, maskTextSelector: string | null, maskAll: boolean | undefined, inlineStylesheet: boolean, maskInputOptions: MaskInputOptions, maskTextFn: MaskTextFn | undefined, maskInputFn: MaskInputFn | undefined, maskImageFn: MaskImageFn | undefined, recordCanvas: boolean, inlineImages: boolean, slimDOMOptions: SlimDOMOptions, dataURLOptions: DataURLOptions, doc: Document, mirror: Mirror, iframeManager: IframeManager, shadowDomManager: ShadowDomManager, canvasManager: CanvasManager): void;
     freeze(): void;
     unfreeze(): void;
     isFrozen(): boolean;
     lock(): void;
     unlock(): void;
+    reset(): void;
     processMutations: (mutations: mutationRecord[]) => void;
     emit: () => void;
     private processMutation;

--- a/packages/rrweb/typings/record/observer.d.ts
+++ b/packages/rrweb/typings/record/observer.d.ts
@@ -1,10 +1,11 @@
-import { MaskInputOptions, SlimDOMOptions, MaskInputFn, MaskTextFn, MaskImageFn } from 'rrweb-snapshot';
+import { MaskInputOptions, SlimDOMOptions, MaskInputFn, MaskTextFn, MaskImageFn, DataURLOptions } from 'rrweb-snapshot';
 import { mutationCallBack, observerParam, listenerHandler, scrollCallback, blockClass, maskTextClass, hooksParam, SamplingStrategy, Mirror } from '../types';
 import MutationBuffer from './mutation';
 import { IframeManager } from './iframe-manager';
 import { ShadowDomManager } from './shadow-dom-manager';
+import { CanvasManager } from './observers/canvas/canvas-manager';
 export declare const mutationBuffers: MutationBuffer[];
-export declare function initMutationObserver(cb: mutationCallBack, doc: Document, blockClass: blockClass, blockSelector: string | null, maskTextClass: maskTextClass, maskTextSelector: string | null, maskAll: boolean | undefined, inlineStylesheet: boolean, maskInputOptions: MaskInputOptions, maskTextFn: MaskTextFn | undefined, maskInputFn: MaskInputFn | undefined, maskImageFn: MaskImageFn | undefined, recordCanvas: boolean, inlineImages: boolean, slimDOMOptions: SlimDOMOptions, mirror: Mirror, iframeManager: IframeManager, shadowDomManager: ShadowDomManager, rootEl: Node): MutationObserver;
+export declare function initMutationObserver(cb: mutationCallBack, doc: Document, blockClass: blockClass, blockSelector: string | null, maskTextClass: maskTextClass, maskTextSelector: string | null, maskAll: boolean | undefined, inlineStylesheet: boolean, maskInputOptions: MaskInputOptions, maskTextFn: MaskTextFn | undefined, maskInputFn: MaskInputFn | undefined, maskImageFn: MaskImageFn | undefined, recordCanvas: boolean, inlineImages: boolean, slimDOMOptions: SlimDOMOptions, dataURLOptions: DataURLOptions, mirror: Mirror, iframeManager: IframeManager, shadowDomManager: ShadowDomManager, canvasManager: CanvasManager, rootEl: Node): MutationObserver;
 export declare function initScrollObserver(cb: scrollCallback, doc: Document, mirror: Mirror, blockClass: blockClass, sampling: SamplingStrategy): listenerHandler;
 export declare const INPUT_TAGS: string[];
 export declare function initObservers(o: observerParam, hooks?: hooksParam): listenerHandler;

--- a/packages/rrweb/typings/record/observers/canvas/2d.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/2d.d.ts
@@ -1,0 +1,2 @@
+import { blockClass, canvasManagerMutationCallback, IWindow, listenerHandler } from '../../../types';
+export default function initCanvas2DMutationObserver(cb: canvasManagerMutationCallback, win: IWindow, blockClass: blockClass, blockSelector: string | null): listenerHandler;

--- a/packages/rrweb/typings/record/observers/canvas/canvas-manager.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/canvas-manager.d.ts
@@ -1,0 +1,37 @@
+import type { DataURLOptions } from 'rrweb-snapshot';
+import { blockClass, canvasMutationCallback, IWindow, Mirror } from '../../../types';
+export declare type RafStamps = {
+    latestId: number;
+    invokeId: number | null;
+};
+export declare class CanvasManager {
+    private pendingCanvasMutations;
+    private rafStamps;
+    private mirror;
+    private mutationCb;
+    private resetObservers?;
+    private frozen;
+    private locked;
+    reset(): void;
+    freeze(): void;
+    unfreeze(): void;
+    lock(): void;
+    unlock(): void;
+    constructor(options: {
+        recordCanvas: boolean;
+        mutationCb: canvasMutationCallback;
+        win: IWindow;
+        blockClass: blockClass;
+        blockSelector: string | null;
+        mirror: Mirror;
+        sampling?: 'all' | number;
+        dataURLOptions: DataURLOptions;
+    });
+    private processMutation;
+    private initCanvasFPSObserver;
+    private initCanvasMutationObserver;
+    private startPendingCanvasMutationFlusher;
+    private startRAFTimestamping;
+    flushPendingCanvasMutations(): void;
+    flushPendingCanvasMutationFor(canvas: HTMLCanvasElement, id: number): void;
+}

--- a/packages/rrweb/typings/record/observers/canvas/canvas.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/canvas.d.ts
@@ -1,0 +1,2 @@
+import type { blockClass, IWindow, listenerHandler } from '../../../types';
+export default function initCanvasContextObserver(win: IWindow, blockClass: blockClass, blockSelector: string | null, setPreserveDrawingBufferToTrue: boolean): listenerHandler;

--- a/packages/rrweb/typings/record/observers/canvas/serialize-args.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/serialize-args.d.ts
@@ -1,0 +1,6 @@
+import type { IWindow, CanvasArg } from '../../../types';
+export declare function variableListFor(ctx: RenderingContext, ctor: string): unknown[];
+export declare const saveWebGLVar: (value: unknown, win: IWindow, ctx: RenderingContext) => number | void;
+export declare function serializeArg(value: unknown, win: IWindow, ctx: RenderingContext): CanvasArg;
+export declare const serializeArgs: (args: Array<unknown>, win: IWindow, ctx: RenderingContext) => CanvasArg[];
+export declare const isInstanceOfWebGLObject: (value: unknown, win: IWindow) => value is WebGLShader | WebGLBuffer | WebGLVertexArrayObject | WebGLTexture | WebGLProgram | WebGLActiveInfo | WebGLUniformLocation | WebGLFramebuffer | WebGLRenderbuffer | WebGLShaderPrecisionFormat;

--- a/packages/rrweb/typings/record/observers/canvas/webgl.d.ts
+++ b/packages/rrweb/typings/record/observers/canvas/webgl.d.ts
@@ -1,0 +1,2 @@
+import { blockClass, canvasManagerMutationCallback, IWindow, listenerHandler } from '../../../types';
+export default function initCanvasWebGLMutationObserver(cb: canvasManagerMutationCallback, win: IWindow, blockClass: blockClass, blockSelector: string | null): listenerHandler;

--- a/packages/rrweb/typings/record/shadow-dom-manager.d.ts
+++ b/packages/rrweb/typings/record/shadow-dom-manager.d.ts
@@ -1,6 +1,7 @@
 import { mutationCallBack, blockClass, maskTextClass, Mirror, scrollCallback, SamplingStrategy } from '../types';
-import { MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn, MaskImageFn } from 'rrweb-snapshot';
+import { MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn, MaskImageFn, DataURLOptions } from 'rrweb-snapshot';
 import { IframeManager } from './iframe-manager';
+import { CanvasManager } from './observers/canvas/canvas-manager';
 declare type BypassOptions = {
     blockClass: blockClass;
     blockSelector: string | null;
@@ -12,11 +13,13 @@ declare type BypassOptions = {
     maskTextFn: MaskTextFn | undefined;
     maskInputFn: MaskInputFn | undefined;
     maskImageFn?: MaskImageFn;
+    dataURLOptions: DataURLOptions;
     recordCanvas: boolean;
     inlineImages: boolean;
     sampling: SamplingStrategy;
     slimDOMOptions: SlimDOMOptions;
     iframeManager: IframeManager;
+    canvasManager: CanvasManager;
 };
 export declare class ShadowDomManager {
     private mutationCb;

--- a/packages/rrweb/typings/record/workers/image-bitmap-data-url-worker.d.ts
+++ b/packages/rrweb/typings/record/workers/image-bitmap-data-url-worker.d.ts
@@ -1,0 +1,5 @@
+import type { ImageBitmapDataURLWorkerParams, ImageBitmapDataURLWorkerResponse } from '../../types';
+export interface ImageBitmapDataURLRequestWorker {
+    postMessage: (message: ImageBitmapDataURLWorkerParams, transfer?: [ImageBitmap]) => void;
+    onmessage: (message: MessageEvent<ImageBitmapDataURLWorkerResponse>) => void;
+}

--- a/packages/rrweb/typings/record/workers/image-bitmap-data-url.worker.d.ts
+++ b/packages/rrweb/typings/record/workers/image-bitmap-data-url.worker.d.ts
@@ -1,0 +1,5 @@
+import type { ImageBitmapDataURLWorkerParams, ImageBitmapDataURLWorkerResponse } from '../../types';
+export interface ImageBitmapDataURLRequestWorker {
+    postMessage: (message: ImageBitmapDataURLWorkerParams, transfer?: [ImageBitmap]) => void;
+    onmessage: (message: MessageEvent<ImageBitmapDataURLWorkerResponse>) => void;
+}

--- a/packages/rrweb/typings/replay/canvas/2d.d.ts
+++ b/packages/rrweb/typings/replay/canvas/2d.d.ts
@@ -1,0 +1,9 @@
+import type { Replayer } from '../';
+import type { canvasMutationCommand } from '../../types';
+export default function canvasMutation({ event, mutations, target, imageMap, errorHandler, }: {
+    event: Parameters<Replayer['applyIncremental']>[0];
+    mutations: canvasMutationCommand[];
+    target: HTMLCanvasElement;
+    imageMap: Replayer['imageMap'];
+    errorHandler: Replayer['warnCanvasMutationFailed'];
+}): Promise<void>;

--- a/packages/rrweb/typings/replay/canvas/deserialize-args.d.ts
+++ b/packages/rrweb/typings/replay/canvas/deserialize-args.d.ts
@@ -1,0 +1,7 @@
+import type { Replayer } from '../';
+import type { CanvasArg, SerializedCanvasArg } from '../../types';
+export declare function variableListFor(ctx: CanvasRenderingContext2D | WebGLRenderingContext | WebGL2RenderingContext, ctor: string): any[];
+export declare function isSerializedArg(arg: unknown): arg is SerializedCanvasArg;
+export declare function deserializeArg(imageMap: Replayer['imageMap'], ctx: CanvasRenderingContext2D | WebGLRenderingContext | WebGL2RenderingContext | null, preload?: {
+    isUnchanged: boolean;
+}): (arg: CanvasArg) => Promise<any>;

--- a/packages/rrweb/typings/replay/canvas/index.d.ts
+++ b/packages/rrweb/typings/replay/canvas/index.d.ts
@@ -1,0 +1,10 @@
+import type { Replayer } from '..';
+import { canvasMutationData } from '../../types';
+export default function canvasMutation({ event, mutation, target, imageMap, canvasEventMap, errorHandler, }: {
+    event: Parameters<Replayer['applyIncremental']>[0];
+    mutation: canvasMutationData;
+    target: HTMLCanvasElement;
+    imageMap: Replayer['imageMap'];
+    canvasEventMap: Replayer['canvasEventMap'];
+    errorHandler: Replayer['warnCanvasMutationFailed'];
+}): Promise<void>;

--- a/packages/rrweb/typings/replay/canvas/webgl.d.ts
+++ b/packages/rrweb/typings/replay/canvas/webgl.d.ts
@@ -1,0 +1,9 @@
+import type { Replayer } from '../';
+import { CanvasContext, canvasMutationCommand } from '../../types';
+export default function webglMutation({ mutation, target, type, imageMap, errorHandler, }: {
+    mutation: canvasMutationCommand;
+    target: HTMLCanvasElement;
+    type: CanvasContext;
+    imageMap: Replayer['imageMap'];
+    errorHandler: Replayer['warnCanvasMutationFailed'];
+}): Promise<void>;

--- a/packages/rrweb/typings/replay/index.d.ts
+++ b/packages/rrweb/typings/replay/index.d.ts
@@ -20,6 +20,7 @@ export declare class Replayer {
     private virtualStyleRulesMap;
     private cache;
     private imageMap;
+    private canvasEventMap;
     private mirror;
     private firstFullSnapshot;
     private newDocumentQueue;
@@ -55,6 +56,8 @@ export declare class Replayer {
     private collectIframeAndAttachDocument;
     private waitForStylesheetLoad;
     private preloadAllImages;
+    private preloadImages;
+    private deserializeAndPreloadCanvasEvents;
     private applyIncremental;
     private applyMutation;
     private applyScroll;

--- a/packages/rrweb/typings/replay/index.d.ts
+++ b/packages/rrweb/typings/replay/index.d.ts
@@ -59,6 +59,7 @@ export declare class Replayer {
     private preloadImages;
     private deserializeAndPreloadCanvasEvents;
     private applyIncremental;
+    private applyCanvasDimensionStyles;
     private applyMutation;
     private applyScroll;
     private applyInput;

--- a/packages/rrweb/typings/types.d.ts
+++ b/packages/rrweb/typings/types.d.ts
@@ -456,6 +456,10 @@ export declare type ReplayPlugin = {
     handler: (event: eventWithTime, isSync: boolean, context: {
         replayer: Replayer;
     }) => void;
+    onBuild?: (node: Node, context: {
+        id: number;
+        replayer: Replayer;
+    }) => void;
 };
 export declare type playerConfig = {
     speed: number;

--- a/packages/rrweb/typings/types.d.ts
+++ b/packages/rrweb/typings/types.d.ts
@@ -1,9 +1,10 @@
 /// <reference types="css-font-loading-module" />
-import { serializedNodeWithId, idNodeMap, INode, MaskInputOptions, SlimDOMOptions, MaskInputFn, MaskTextFn, MaskImageFn } from 'rrweb-snapshot';
+import { serializedNodeWithId, idNodeMap, INode, MaskInputOptions, SlimDOMOptions, MaskInputFn, MaskTextFn, MaskImageFn, DataURLOptions } from 'rrweb-snapshot';
 import { PackFn, UnpackFn } from './packer/base';
 import { IframeManager } from './record/iframe-manager';
 import { ShadowDomManager } from './record/shadow-dom-manager';
 import type { Replayer } from './replay';
+import { CanvasManager } from './record/observers/canvas/canvas-manager';
 export declare enum EventType {
     DomContentLoaded = 0,
     Load = 1,
@@ -126,6 +127,7 @@ export declare type SamplingStrategy = Partial<{
     media: number;
     input: 'all' | 'last' | 'debounce';
     inputDebounce: number;
+    canvas: 'all' | number;
 }>;
 export declare type RecordPlugin<TOptions = unknown> = {
     name: string;
@@ -159,6 +161,7 @@ export declare type recordOptions<T> = {
     hooks?: hooksParam;
     packFn?: PackFn;
     sampling?: SamplingStrategy;
+    dataURLOptions?: DataURLOptions;
     recordCanvas?: boolean;
     userTriggeredOnInput?: boolean;
     collectFonts?: boolean;
@@ -197,10 +200,12 @@ export declare type observerParam = {
     userTriggeredOnInput: boolean;
     collectFonts: boolean;
     slimDOMOptions: SlimDOMOptions;
+    dataURLOptions: DataURLOptions;
     doc: Document;
     mirror: Mirror;
     iframeManager: IframeManager;
     shadowDomManager: ShadowDomManager;
+    canvasManager: CanvasManager;
     plugins: Array<{
         observer: Function;
         callback: Function;
@@ -297,11 +302,50 @@ export declare enum MouseInteractions {
     TouchEnd = 9,
     TouchCancel = 10
 }
+export declare enum CanvasContext {
+    '2D' = 0,
+    WebGL = 1,
+    WebGL2 = 2
+}
+export declare type SerializedCanvasArg = {
+    rr_type: 'ArrayBuffer';
+    base64: string;
+} | {
+    rr_type: 'Blob';
+    data: Array<CanvasArg>;
+    type?: string;
+} | {
+    rr_type: string;
+    src: string;
+} | {
+    rr_type: string;
+    args: Array<CanvasArg>;
+} | {
+    rr_type: string;
+    index: number;
+};
+export declare type CanvasArg = SerializedCanvasArg | string | number | boolean | null | CanvasArg[];
 declare type mouseInteractionParam = {
     type: MouseInteractions;
     id: number;
     x: number;
     y: number;
+};
+export declare type ImageBitmapDataURLWorkerParams = {
+    id: number;
+    bitmap: ImageBitmap;
+    width: number;
+    height: number;
+    dataURLOptions: DataURLOptions;
+};
+export declare type ImageBitmapDataURLWorkerResponse = {
+    id: number;
+} | {
+    id: number;
+    type: string;
+    base64: string;
+    width: number;
+    height: number;
 };
 export declare type mouseInteractionCallBack = (d: mouseInteractionParam) => void;
 export declare type scrollPosition = {
@@ -336,13 +380,24 @@ export declare type styleDeclarationParam = {
     };
 };
 export declare type styleDeclarationCallback = (s: styleDeclarationParam) => void;
-export declare type canvasMutationCallback = (p: canvasMutationParam) => void;
-export declare type canvasMutationParam = {
-    id: number;
+export declare type canvasMutationCommand = {
     property: string;
     args: Array<unknown>;
     setter?: true;
 };
+export declare type canvasMutationParam = {
+    id: number;
+    type: CanvasContext;
+    commands: canvasMutationCommand[];
+} | ({
+    id: number;
+    type: CanvasContext;
+} & canvasMutationCommand);
+export declare type canvasMutationWithType = {
+    type: CanvasContext;
+} & canvasMutationCommand;
+export declare type canvasMutationCallback = (p: canvasMutationParam) => void;
+export declare type canvasManagerMutationCallback = (target: HTMLCanvasElement, p: canvasMutationWithType) => void;
 export declare type fontParam = {
     family: string;
     fontSource: string;

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -33,6 +33,7 @@ export declare class TreeIndex {
     private scrollMap;
     private inputMap;
     private dialogMap;
+    private canvasAttributesMap;
     constructor();
     add(mutation: addedNodeMutation): void;
     remove(mutation: removedNodeMutation, mirror: Mirror): void;
@@ -41,11 +42,13 @@ export declare class TreeIndex {
     scroll(d: scrollData): void;
     input(d: inputData): void;
     dialog(d: attributeMutation): void;
+    canvasAttribute(d: attributeMutation): void;
     flush(): {
         mutationData: mutationData;
         scrollMap: TreeIndex['scrollMap'];
         inputMap: TreeIndex['inputMap'];
         dialogMap: TreeIndex['dialogMap'];
+        canvasAttributesMap: TreeIndex['canvasAttributesMap'];
     };
     private reset;
     idRemoved(id: number): boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,6 +1783,18 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
+"@rollup/plugin-node-resolve@^13.1.3":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz#da1c5c5ce8316cef96a2f823d111c1e4e498801c"
+  integrity sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    deepmerge "^4.2.2"
+    is-builtin-module "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/plugin-node-resolve@^7.0.0":
   version "7.1.3"
   resolved "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz"
@@ -1825,6 +1837,14 @@
   dependencies:
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
+"@rollup/pluginutils@^4.1.2":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  dependencies:
+    estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
 "@sinonjs/commons@^1.7.0":
@@ -2012,6 +2032,11 @@
   version "2.2.2"
   resolved "https://registry.npmjs.org/@types/nwsapi/-/nwsapi-2.2.2.tgz"
   integrity sha512-C4G47l3cAra4729xbhL9y3PjTpO7LJwXd47Fn1mbnZ6WcTkFPo8iDJPyMGCIudxpc7aeM8K1Fmw+lZfOb5ya9g==
+
+"@types/offscreencanvas@^2019.6.4":
+  version "2019.7.3"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz#90267db13f64d6e9ccb5ae3eac92786a7c77a516"
+  integrity sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2279,6 +2304,15 @@
   version "1.6.1"
   resolved "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.1.tgz"
   integrity sha512-xYKDNuPR36/fUK+jmhM+oauBmbdUAfuJKnDjg3/7NbN+Pj03TX7e94LXnzkwGgAR+U/HWoMqM5UPTuGIYfIx9g==
+
+"@yarn-tool/resolve-package@^1.0.40":
+  version "1.0.47"
+  resolved "https://registry.yarnpkg.com/@yarn-tool/resolve-package/-/resolve-package-1.0.47.tgz#8ec25f291a316280a281632331e88926a66fdf19"
+  integrity sha512-Zaw58gQxjQceJqhqybJi1oUDaORT8i2GTgwICPs8v/X/Pkx35FXQba69ldHVg5pQZ6YLKpROXgyHvBaCJOFXiA==
+  dependencies:
+    pkg-dir "< 6 >= 5"
+    tslib "^2"
+    upath2 "^3.1.13"
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -2928,6 +2962,11 @@ builtin-modules@^3.1.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -4709,7 +4748,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^3.3.1:
+find-cache-dir@^3.3.1, find-cache-dir@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
@@ -4731,6 +4770,14 @@ find-up@^4.0.0, find-up@^4.1.0:
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 findup-sync@~0.3.0:
@@ -4827,6 +4874,15 @@ fs-extra@8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -5566,6 +5622,13 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-builtin-module@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
@@ -7202,6 +7265,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
@@ -8147,6 +8217,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
@@ -8160,6 +8237,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map-series@^2.1.0:
   version "2.1.0"
@@ -8342,6 +8426,13 @@ path-is-inside@^1.0.1:
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
+path-is-network-drive@^1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/path-is-network-drive/-/path-is-network-drive-1.0.21.tgz#7c40e72b1b3750b4aa7f7f40e94a35be7b33bcfd"
+  integrity sha512-B1PzE3CgxNKY0/69Urjw3KNi4K+4q4IBsvq02TwURsdNLZj2YUn0HGw2o26IrGV4YUffg7IHZiwKJ/EDhXMQyg==
+  dependencies:
+    tslib "^2"
+
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
@@ -8356,6 +8447,13 @@ path-parse@^1.0.6:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-strip-sep@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/path-strip-sep/-/path-strip-sep-1.0.18.tgz#243d9257ea85b872db826922ea16905e523187e1"
+  integrity sha512-IGC/vjHigvKV9RsE4ArZiGNkqNrb0tk1j/HO0TS49duEUqGSy1y464XhCWyTLFwqe7w7wFsdCX9fqUmAHoUaxA==
+  dependencies:
+    tslib "^2"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -8442,6 +8540,13 @@ pirates@^4.0.4:
   version "4.0.4"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz"
   integrity sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==
+
+"pkg-dir@< 6 >= 5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
@@ -9444,10 +9549,10 @@ rollup-plugin-postcss@^3.1.1:
     safe-identifier "^0.4.1"
     style-inject "^0.3.0"
 
-rollup-plugin-rename-node-modules@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.1.0.tgz"
-  integrity sha512-JpfsJ7NYI/4OdqWvZ/BY6fgjZb5j7sRFvHMv8EU0zrFiNUcW4ke9tw7WXImsHnjq7Bp3xv+UILRPpA7plOa38Q==
+rollup-plugin-rename-node-modules@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz#d80091fc817ce726e7cdfc388ec2f4da286e280f"
+  integrity sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==
   dependencies:
     estree-walker "^2.0.1"
     magic-string "^0.25.7"
@@ -9481,6 +9586,23 @@ rollup-plugin-typescript2@^0.30.0:
     resolve "1.20.0"
     tslib "2.1.0"
 
+rollup-plugin-typescript2@^0.31.2:
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.2.tgz#463aa713a7e2bf85b92860094b9f7fb274c5a4d8"
+  integrity sha512-hRwEYR1C8xDGVVMFJQdEVnNAeWRvpaY97g5mp3IeLnzhNXzSVq78Ye/BJ9PAaUfN4DXa/uDnqerifMOaMFY54Q==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.2"
+    "@yarn-tool/resolve-package" "^1.0.40"
+    find-cache-dir "^3.3.2"
+    fs-extra "^10.0.0"
+    resolve "^1.20.0"
+    tslib "^2.3.1"
+
+rollup-plugin-web-worker-loader@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.6.1.tgz#9d7a27575b64b0780fe4e8b3bc87470d217e485f"
+  integrity sha512-4QywQSz1NXFHKdyiou16mH3ijpcfLtLGOrAqvAqu1Gx+P8+zj+3gwC2BSL/VW1d+LW4nIHC8F7d7OXhs9UdR2A==
+
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz"
@@ -9502,27 +9624,17 @@ rollup@^2.56.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rrweb-snapshot@^1.1.12, rrweb-snapshot@^1.1.14:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
-  integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
+rollup@^2.68.0:
+  version "2.79.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.79.2.tgz#f150e4a5db4b121a21a747d762f701e5e9f49090"
+  integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 "rrweb-snapshot@npm:@atlasinc/rrweb-snapshot@1.1.19":
   version "1.1.19"
   resolved "https://registry.yarnpkg.com/@atlasinc/rrweb-snapshot/-/rrweb-snapshot-1.1.19.tgz#b7e6a2899b4791453e222be2dbcf40e24655ca78"
   integrity sha512-nkapJR2WPwGYy/z/PF8jsJtqDS0uDmWzgclVTiaGkj3nqC5Ntuk+r/8CXfD+oa8ldTW0g6X3ClDJ7zeATZfGag==
-
-rrweb@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.3.tgz#4fbb3d473d71c79b6c30a54e585e5a01c8ac08bb"
-  integrity sha512-F2qp8LteJLyycsv+lCVJqtVpery63L3U+/ogqMA0da8R7Jx57o6gT+HpjrzdeeGMIBZR7kKNaKyJwDupTTu5KA==
-  dependencies:
-    "@types/css-font-loading-module" "0.0.7"
-    "@xstate/fsm" "^1.4.0"
-    base64-arraybuffer "^1.0.1"
-    fflate "^0.4.4"
-    mitt "^1.1.3"
-    rrweb-snapshot "^1.1.14"
 
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
@@ -10460,6 +10572,11 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2, tslib@^2.3.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tslib@^2.0.0, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz"
@@ -10681,6 +10798,16 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz"
   integrity sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=
+
+upath2@^3.1.13:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/upath2/-/upath2-3.1.20.tgz#3a914d15b95c7675b0bc552afdc0c679912ff8a8"
+  integrity sha512-g+t9q+MrIsX60eJzF4I/YNYmRmrT0HJnnEaenbUy/FFO1lY04YQoiJ/qS4Ou+a+D9WUPxN0cVUYXkkX9b1EAMw==
+  dependencies:
+    "@types/node" "*"
+    path-is-network-drive "^1.0.21"
+    path-strip-sep "^1.0.18"
+    tslib "^2"
 
 upath@^2.0.1:
   version "2.0.1"
@@ -11118,3 +11245,8 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
Apply patches/prs related to canvas recording from rrweb repository:

https://github.com/rrweb-io/rrweb/pull/859
https://github.com/rrweb-io/rrweb/pull/967
https://github.com/rrweb-io/rrweb/pull/1012

Introduce plugin (from sentry) to replay canvas, instead of using `UNSAFE_replayCanvas` (removing sandbox/allowing-scripts on replayer iframe):
https://github.com/getsentry/sentry/blob/805cc77821e35405b70d0f2b41d553f6d6a15b9e/static/app/components/replays/canvasReplayerPlugin.tsx