### PR TITLE
Split big mutation payload into smaller events to process separately

### DIFF
--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@atlasinc/rrweb-snapshot",
+  "name": "rrweb-snapshot",
   "version": "1.1.20",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rrweb-snapshot",
+  "name": "@atlasinc/rrweb-snapshot",
   "version": "1.1.20",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@atlasinc/rrweb",
+  "name": "rrweb",
   "version": "1.1.26",
   "description": "record and replay the web",
   "scripts": {

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rrweb",
-  "version": "1.1.26",
+  "name": "@atlasinc/rrweb",
+  "version": "1.1.27",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/typings/replay/index.d.ts
+++ b/packages/rrweb/typings/replay/index.d.ts
@@ -27,7 +27,7 @@ export declare class Replayer {
     private mousePos;
     private touchActive;
     private lastApplyCancelFn?;
-    constructor(events: Array<eventWithTime | string>, config?: Partial<playerConfig>);
+    constructor(originalEvents: Array<eventWithTime | string>, config?: Partial<playerConfig>);
     on(event: string, handler: Handler): this;
     off(event: string, handler: Handler): this;
     setConfig(config: Partial<playerConfig>): void;

--- a/packages/rrweb/typings/utils.d.ts
+++ b/packages/rrweb/typings/utils.d.ts
@@ -1,4 +1,4 @@
-import { Mirror, throttleOptions, listenerHandler, hookResetter, blockClass, addedNodeMutation, removedNodeMutation, textMutation, attributeMutation, mutationData, scrollData, inputData, DocumentDimension, IWindow } from './types';
+import { Mirror, throttleOptions, listenerHandler, hookResetter, blockClass, addedNodeMutation, removedNodeMutation, textMutation, attributeMutation, mutationData, scrollData, inputData, DocumentDimension, IWindow, eventWithTime } from './types';
 import { INode, serializedNodeWithId } from 'rrweb-snapshot';
 export declare function on(type: string, fn: EventListenerOrEventListenerObject, target?: Document | IWindow): listenerHandler;
 export declare function createMirror(): Mirror;
@@ -73,4 +73,5 @@ export declare function hasShadowRoot<T extends Node>(n: T): n is T & {
     shadowRoot: ShadowRoot;
 };
 export declare function asyncLoop<T>(items: T[], fn: (item: T, index: number) => void, done: () => void): () => void;
+export declare function splitMutationIntoMultipleEvents(event: eventWithTime): eventWithTime[];
 export {};


### PR DESCRIPTION
There are cases when one single event contains ~100K mutations, 
Splitting them into smaller events (max 200 per batch) to process separately (offload main thread)