### PR TITLE
Canvas replay plugin: Don't remove src from img

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@atlasinc/rrweb",
-  "version": "1.1.28",
+  "name": "rrweb",
+  "version": "1.1.29",
   "description": "record and replay the web",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb/src/plugins/replay-canvas-plugin/plugin.ts
+++ b/packages/rrweb/src/plugins/replay-canvas-plugin/plugin.ts
@@ -226,25 +226,7 @@ export function CanvasReplayerPlugin(
   // Debounce so that `processEvent` is not called immediately. We want to only
   // process the most recent event, otherwise it will look like the canvas is
   // animating when we seek throughout replay.
-  //
-  // `handleQueue` is really a map of canvas id -> most recent canvas mutation
-  // event for all canvas mutation events before the current replay time
   const debouncedProcessQueuedEvents = debounce(function processQueuedEvents() {
-    const canvasIds = Array.from(canvases.keys());
-    const queuedEventIds = Array.from(handleQueue.keys());
-    const queuedEventIdsSet = new Set(queuedEventIds);
-    const unusedCanvases = canvasIds.filter((id) => !queuedEventIdsSet.has(id));
-
-    // Compare the canvas ids from canvas mutation events against existing
-    // canvases and remove the canvas snapshot for previously drawn to
-    // canvases that do not currently exist in this new point of time
-    unusedCanvases.forEach((id) => {
-      const el = containers.get(id);
-      if (el) {
-        el.src = '';
-      }
-    });
-
     // Find all canvases with an event that needs to process
     Array.from(handleQueue.entries()).forEach(async ([id, [e, replayer]]) => {
       try {


### PR DESCRIPTION
Cleanup logic was actually removing `src`-s of needed elements,
Canvas replay will now always show the last rendered image for each canvas